### PR TITLE
feat(echo-http): Add comprehensive HTTP testing endpoints

### DIFF
--- a/echo-http/README.md
+++ b/echo-http/README.md
@@ -34,17 +34,69 @@ docker run -p 8080:8080 -v $(pwd)/.env:/app/.env ghcr.io/jsr-probitas/echo-http:
 
 ## API
 
-| Endpoint           | Method | Description                               |
-| ------------------ | ------ | ----------------------------------------- |
-| `/get`             | GET    | Echo request info (query params, headers) |
-| `/post`            | POST   | Echo request body (JSON, form data)       |
-| `/put`             | PUT    | Echo request body                         |
-| `/patch`           | PATCH  | Echo request body                         |
-| `/delete`          | DELETE | Echo request info                         |
-| `/headers`         | GET    | Echo headers only                         |
-| `/status/{code}`   | GET    | Return specified status code (100-599)    |
-| `/delay/{seconds}` | GET    | Echo after delay                          |
-| `/health`          | GET    | Health check                              |
+### Echo Endpoints
+
+| Endpoint     | Method | Description                               |
+| ------------ | ------ | ----------------------------------------- |
+| `/get`       | GET    | Echo request info (query params, headers) |
+| `/post`      | POST   | Echo request body (JSON, form data)       |
+| `/put`       | PUT    | Echo request body                         |
+| `/patch`     | PATCH  | Echo request body                         |
+| `/delete`    | DELETE | Echo request info                         |
+| `/anything`  | ANY    | Echo any request (method, headers, body)  |
+| `/anything/*`| ANY    | Echo any request with path                |
+
+### Utility Endpoints
+
+| Endpoint           | Method | Description                            |
+| ------------------ | ------ | -------------------------------------- |
+| `/headers`         | GET    | Echo headers only                      |
+| `/ip`              | GET    | Return client IP address               |
+| `/user-agent`      | GET    | Return User-Agent header               |
+| `/status/{code}`   | ANY    | Return specified status code (100-599) |
+| `/delay/{seconds}` | GET    | Echo after delay (max 30s)             |
+| `/health`          | GET    | Health check                           |
+
+### Redirect Endpoints
+
+| Endpoint               | Method | Description                           |
+| ---------------------- | ------ | ------------------------------------- |
+| `/redirect/{n}`        | GET    | Redirect n times before final response|
+| `/redirect-to`         | GET    | Redirect to URL (?url=...&status_code=)|
+| `/absolute-redirect/{n}`| GET   | Redirect n times with absolute URLs   |
+| `/relative-redirect/{n}`| GET   | Redirect n times with relative URLs   |
+
+### Authentication Endpoints
+
+| Endpoint                     | Method | Description                              |
+| ---------------------------- | ------ | ---------------------------------------- |
+| `/basic-auth/{user}/{pass}`  | GET    | Basic auth (200 if match, 401 otherwise) |
+| `/hidden-basic-auth/{user}/{pass}` | GET | Basic auth (200 if match, 404 otherwise)|
+| `/bearer`                    | GET    | Bearer token validation                  |
+
+### Cookie Endpoints
+
+| Endpoint          | Method | Description                              |
+| ----------------- | ------ | ---------------------------------------- |
+| `/cookies`        | GET    | Echo request cookies                     |
+| `/cookies/set`    | GET    | Set cookies (?name=value) and redirect   |
+| `/cookies/delete` | GET    | Delete cookies (?name) and redirect      |
+
+### Binary Data Endpoints
+
+| Endpoint       | Method | Description                      |
+| -------------- | ------ | -------------------------------- |
+| `/bytes/{n}`   | GET    | Return n random bytes (max 100KB)|
+| `/stream/{n}`  | GET    | Stream n JSON lines (max 100)    |
+| `/drip`        | GET    | Drip data (?duration=&numbytes=&delay=)|
+
+### Compression Endpoints
+
+| Endpoint    | Method | Description                   |
+| ----------- | ------ | ----------------------------- |
+| `/gzip`     | GET    | Return gzip-compressed response |
+| `/deflate`  | GET    | Return deflate-compressed response |
+| `/brotli`   | GET    | Return brotli-compressed response |
 
 See [docs/api.md](./docs/api.md) for detailed API reference.
 
@@ -78,6 +130,32 @@ curl http://localhost:8080/status/418
 
 # Delayed response (for timeout testing)
 curl http://localhost:8080/delay/5
+
+# Redirect testing
+curl -L http://localhost:8080/redirect/3
+
+# Basic authentication
+curl -u user:pass http://localhost:8080/basic-auth/user/pass
+
+# Bearer token
+curl -H "Authorization: Bearer my-token" http://localhost:8080/bearer
+
+# Cookie handling
+curl -c cookies.txt http://localhost:8080/cookies/set?session=abc123
+curl -b cookies.txt http://localhost:8080/cookies
+
+# Get client IP
+curl http://localhost:8080/ip
+
+# Compression testing
+curl --compressed http://localhost:8080/gzip
+curl --compressed http://localhost:8080/brotli
+
+# Stream data
+curl http://localhost:8080/stream/5
+
+# Random bytes
+curl http://localhost:8080/bytes/100 --output random.bin
 ```
 
 ## Development

--- a/echo-http/go.mod
+++ b/echo-http/go.mod
@@ -3,6 +3,7 @@ module github.com/jsr-probitas/dockerfiles/echo-http
 go 1.23
 
 require (
+	github.com/andybalholm/brotli v1.1.1
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/joho/godotenv v1.5.1
 )

--- a/echo-http/go.sum
+++ b/echo-http/go.sum
@@ -1,4 +1,8 @@
+github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
+github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=

--- a/echo-http/handlers/anything.go
+++ b/echo-http/handlers/anything.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type AnythingResponse struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Args    map[string]string `json:"args"`
+	Headers map[string]string `json:"headers"`
+	Origin  string            `json:"origin"`
+	Data    string            `json:"data,omitempty"`
+	JSON    any               `json:"json,omitempty"`
+	Form    map[string]string `json:"form,omitempty"`
+	Files   map[string]string `json:"files,omitempty"`
+}
+
+// AnythingHandler echoes any request information.
+// ANY /anything - Echo any request (method, headers, body, etc.)
+// ANY /anything/{path} - Echo any request with path
+func AnythingHandler(w http.ResponseWriter, r *http.Request) {
+	response := AnythingResponse{
+		Method:  r.Method,
+		URL:     r.URL.RequestURI(),
+		Args:    make(map[string]string),
+		Headers: make(map[string]string),
+		Origin:  getClientIP(r),
+	}
+
+	for key, values := range r.URL.Query() {
+		if len(values) > 0 {
+			response.Args[key] = values[0]
+		}
+	}
+
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			response.Headers[key] = values[0]
+		}
+	}
+
+	if r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodDelete {
+		body, err := io.ReadAll(r.Body)
+		if err == nil && len(body) > 0 {
+			response.Data = string(body)
+
+			contentType := r.Header.Get("Content-Type")
+			if strings.Contains(contentType, "application/json") {
+				var jsonData any
+				if err := json.Unmarshal(body, &jsonData); err == nil {
+					response.JSON = jsonData
+				}
+			} else if strings.Contains(contentType, "application/x-www-form-urlencoded") {
+				r.Body = io.NopCloser(strings.NewReader(string(body)))
+				if err := r.ParseForm(); err == nil {
+					formData := make(map[string]string)
+					for key, values := range r.PostForm {
+						if len(values) > 0 {
+							formData[key] = values[0]
+						}
+					}
+					response.Form = formData
+				}
+			} else if strings.Contains(contentType, "multipart/form-data") {
+				r.Body = io.NopCloser(strings.NewReader(string(body)))
+				if err := r.ParseMultipartForm(32 << 20); err == nil {
+					if r.MultipartForm != nil {
+						formData := make(map[string]string)
+						for key, values := range r.MultipartForm.Value {
+							if len(values) > 0 {
+								formData[key] = values[0]
+							}
+						}
+						response.Form = formData
+
+						files := make(map[string]string)
+						for key, fileHeaders := range r.MultipartForm.File {
+							if len(fileHeaders) > 0 {
+								files[key] = fileHeaders[0].Filename
+							}
+						}
+						response.Files = files
+					}
+				}
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/echo-http/handlers/anything_test.go
+++ b/echo-http/handlers/anything_test.go
@@ -1,0 +1,198 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestAnythingHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		body           string
+		contentType    string
+		expectedMethod string
+	}{
+		{
+			name:           "GET request",
+			method:         http.MethodGet,
+			path:           "/anything?foo=bar",
+			expectedMethod: "GET",
+		},
+		{
+			name:           "POST request with JSON",
+			method:         http.MethodPost,
+			path:           "/anything",
+			body:           `{"key":"value"}`,
+			contentType:    "application/json",
+			expectedMethod: "POST",
+		},
+		{
+			name:           "PUT request",
+			method:         http.MethodPut,
+			path:           "/anything",
+			body:           `{"key":"value"}`,
+			contentType:    "application/json",
+			expectedMethod: "PUT",
+		},
+		{
+			name:           "PATCH request",
+			method:         http.MethodPatch,
+			path:           "/anything",
+			body:           `{"key":"value"}`,
+			contentType:    "application/json",
+			expectedMethod: "PATCH",
+		},
+		{
+			name:           "DELETE request",
+			method:         http.MethodDelete,
+			path:           "/anything",
+			expectedMethod: "DELETE",
+		},
+		{
+			name:           "POST with form data",
+			method:         http.MethodPost,
+			path:           "/anything",
+			body:           "username=test&password=secret",
+			contentType:    "application/x-www-form-urlencoded",
+			expectedMethod: "POST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.HandleFunc("/anything", AnythingHandler)
+			r.HandleFunc("/anything/*", AnythingHandler)
+
+			var body *strings.Reader
+			if tt.body != "" {
+				body = strings.NewReader(tt.body)
+			} else {
+				body = strings.NewReader("")
+			}
+
+			req := httptest.NewRequest(tt.method, tt.path, body)
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			req.RemoteAddr = "192.168.1.100:12345"
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+			}
+
+			var response AnythingResponse
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if response.Method != tt.expectedMethod {
+				t.Errorf("expected method %s, got %s", tt.expectedMethod, response.Method)
+			}
+
+			if response.Origin != "192.168.1.100" {
+				t.Errorf("expected origin 192.168.1.100, got %s", response.Origin)
+			}
+		})
+	}
+}
+
+func TestAnythingHandlerQueryParams(t *testing.T) {
+	r := chi.NewRouter()
+	r.HandleFunc("/anything", AnythingHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/anything?foo=bar&baz=qux", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	var response AnythingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Args["foo"] != "bar" {
+		t.Errorf("expected foo=bar, got foo=%s", response.Args["foo"])
+	}
+	if response.Args["baz"] != "qux" {
+		t.Errorf("expected baz=qux, got baz=%s", response.Args["baz"])
+	}
+}
+
+func TestAnythingHandlerHeaders(t *testing.T) {
+	r := chi.NewRouter()
+	r.HandleFunc("/anything", AnythingHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/anything", nil)
+	req.Header.Set("X-Custom-Header", "custom-value")
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	var response AnythingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Headers["X-Custom-Header"] != "custom-value" {
+		t.Errorf("expected X-Custom-Header=custom-value, got %s", response.Headers["X-Custom-Header"])
+	}
+}
+
+func TestAnythingHandlerJSONBody(t *testing.T) {
+	r := chi.NewRouter()
+	r.HandleFunc("/anything", AnythingHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/anything", strings.NewReader(`{"name":"test","count":42}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	var response AnythingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Data != `{"name":"test","count":42}` {
+		t.Errorf("unexpected data: %s", response.Data)
+	}
+
+	if response.JSON == nil {
+		t.Error("expected JSON field to be populated")
+	}
+}
+
+func TestAnythingHandlerFormBody(t *testing.T) {
+	r := chi.NewRouter()
+	r.HandleFunc("/anything", AnythingHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/anything", strings.NewReader("username=test&password=secret"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	var response AnythingResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Form["username"] != "test" {
+		t.Errorf("expected username=test, got %s", response.Form["username"])
+	}
+	if response.Form["password"] != "secret" {
+		t.Errorf("expected password=secret, got %s", response.Form["password"])
+	}
+}

--- a/echo-http/handlers/auth.go
+++ b/echo-http/handlers/auth.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type AuthResponse struct {
+	Authenticated bool   `json:"authenticated"`
+	User          string `json:"user,omitempty"`
+	Token         string `json:"token,omitempty"`
+}
+
+// BasicAuthHandler validates Basic Authentication credentials.
+// GET /basic-auth/{user}/{pass} - Returns 200 if credentials match, 401 otherwise
+func BasicAuthHandler(w http.ResponseWriter, r *http.Request) {
+	expectedUser := chi.URLParam(r, "user")
+	expectedPass := chi.URLParam(r, "pass")
+
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Use constant-time comparison to prevent timing attacks
+	userMatch := subtle.ConstantTimeCompare([]byte(user), []byte(expectedUser)) == 1
+	passMatch := subtle.ConstantTimeCompare([]byte(pass), []byte(expectedPass)) == 1
+
+	if !userMatch || !passMatch {
+		w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	response := AuthResponse{
+		Authenticated: true,
+		User:          user,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// HiddenBasicAuthHandler is similar to BasicAuthHandler but doesn't prompt for credentials.
+// GET /hidden-basic-auth/{user}/{pass} - Returns 404 instead of 401 if not authenticated
+func HiddenBasicAuthHandler(w http.ResponseWriter, r *http.Request) {
+	expectedUser := chi.URLParam(r, "user")
+	expectedPass := chi.URLParam(r, "pass")
+
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	userMatch := subtle.ConstantTimeCompare([]byte(user), []byte(expectedUser)) == 1
+	passMatch := subtle.ConstantTimeCompare([]byte(pass), []byte(expectedPass)) == 1
+
+	if !userMatch || !passMatch {
+		http.NotFound(w, r)
+		return
+	}
+
+	response := AuthResponse{
+		Authenticated: true,
+		User:          user,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// BearerHandler validates Bearer token authentication.
+// GET /bearer - Returns 200 if valid Bearer token present, 401 otherwise
+func BearerHandler(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		w.Header().Set("WWW-Authenticate", `Bearer`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		w.Header().Set("WWW-Authenticate", `Bearer`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	token := parts[1]
+	if token == "" {
+		w.Header().Set("WWW-Authenticate", `Bearer`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	response := AuthResponse{
+		Authenticated: true,
+		Token:         token,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/echo-http/handlers/auth_test.go
+++ b/echo-http/handlers/auth_test.go
@@ -1,0 +1,239 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestBasicAuthHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           string
+		pass           string
+		authUser       string
+		authPass       string
+		setAuth        bool
+		expectedStatus int
+		authenticated  bool
+	}{
+		{
+			name:           "correct credentials",
+			user:           "testuser",
+			pass:           "testpass",
+			authUser:       "testuser",
+			authPass:       "testpass",
+			setAuth:        true,
+			expectedStatus: http.StatusOK,
+			authenticated:  true,
+		},
+		{
+			name:           "wrong password",
+			user:           "testuser",
+			pass:           "testpass",
+			authUser:       "testuser",
+			authPass:       "wrongpass",
+			setAuth:        true,
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "wrong username",
+			user:           "testuser",
+			pass:           "testpass",
+			authUser:       "wronguser",
+			authPass:       "testpass",
+			setAuth:        true,
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "no auth header",
+			user:           "testuser",
+			pass:           "testpass",
+			setAuth:        false,
+			expectedStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/basic-auth/{user}/{pass}", BasicAuthHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/basic-auth/"+tt.user+"/"+tt.pass, nil)
+			if tt.setAuth {
+				req.SetBasicAuth(tt.authUser, tt.authPass)
+			}
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.authenticated {
+				var response AuthResponse
+				if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if !response.Authenticated {
+					t.Error("expected authenticated to be true")
+				}
+				if response.User != tt.authUser {
+					t.Errorf("expected user %q, got %q", tt.authUser, response.User)
+				}
+			}
+
+			if tt.expectedStatus == http.StatusUnauthorized {
+				wwwAuth := rec.Header().Get("WWW-Authenticate")
+				if wwwAuth == "" {
+					t.Error("expected WWW-Authenticate header")
+				}
+			}
+		})
+	}
+}
+
+func TestHiddenBasicAuthHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           string
+		pass           string
+		authUser       string
+		authPass       string
+		setAuth        bool
+		expectedStatus int
+	}{
+		{
+			name:           "correct credentials",
+			user:           "testuser",
+			pass:           "testpass",
+			authUser:       "testuser",
+			authPass:       "testpass",
+			setAuth:        true,
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:           "wrong credentials returns 404",
+			user:           "testuser",
+			pass:           "testpass",
+			authUser:       "testuser",
+			authPass:       "wrongpass",
+			setAuth:        true,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "no auth returns 404",
+			user:           "testuser",
+			pass:           "testpass",
+			setAuth:        false,
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/hidden-basic-auth/{user}/{pass}", HiddenBasicAuthHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/hidden-basic-auth/"+tt.user+"/"+tt.pass, nil)
+			if tt.setAuth {
+				req.SetBasicAuth(tt.authUser, tt.authPass)
+			}
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+		})
+	}
+}
+
+func TestBearerHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		authHeader     string
+		expectedStatus int
+		authenticated  bool
+		expectedToken  string
+	}{
+		{
+			name:           "valid bearer token",
+			authHeader:     "Bearer my-secret-token",
+			expectedStatus: http.StatusOK,
+			authenticated:  true,
+			expectedToken:  "my-secret-token",
+		},
+		{
+			name:           "case insensitive bearer",
+			authHeader:     "bearer my-token",
+			expectedStatus: http.StatusOK,
+			authenticated:  true,
+			expectedToken:  "my-token",
+		},
+		{
+			name:           "no auth header",
+			authHeader:     "",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "wrong auth type",
+			authHeader:     "Basic dXNlcjpwYXNz",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "empty token",
+			authHeader:     "Bearer ",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
+			name:           "malformed header",
+			authHeader:     "Bearer",
+			expectedStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/bearer", BearerHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/bearer", nil)
+			if tt.authHeader != "" {
+				req.Header.Set("Authorization", tt.authHeader)
+			}
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.authenticated {
+				var response AuthResponse
+				if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if !response.Authenticated {
+					t.Error("expected authenticated to be true")
+				}
+				if response.Token != tt.expectedToken {
+					t.Errorf("expected token %q, got %q", tt.expectedToken, response.Token)
+				}
+			}
+
+			if tt.expectedStatus == http.StatusUnauthorized {
+				wwwAuth := rec.Header().Get("WWW-Authenticate")
+				if wwwAuth == "" {
+					t.Error("expected WWW-Authenticate header")
+				}
+			}
+		})
+	}
+}

--- a/echo-http/handlers/bytes.go
+++ b/echo-http/handlers/bytes.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	maxBytesSize = 100 * 1024 // 100KB
+)
+
+// BytesHandler returns n random bytes.
+// GET /bytes/{n} - Return n random bytes
+func BytesHandler(w http.ResponseWriter, r *http.Request) {
+	nStr := chi.URLParam(r, "n")
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n < 0 || n > maxBytesSize {
+		http.Error(w, fmt.Sprintf("Invalid byte count (must be 0-%d)", maxBytesSize), http.StatusBadRequest)
+		return
+	}
+
+	if n == 0 {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "0")
+		return
+	}
+
+	data := make([]byte, n)
+	if _, err := rand.Read(data); err != nil {
+		http.Error(w, "Failed to generate random bytes", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.Itoa(n))
+	_, _ = w.Write(data)
+}

--- a/echo-http/handlers/bytes_test.go
+++ b/echo-http/handlers/bytes_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestBytesHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		n              string
+		expectedStatus int
+		expectedLength int
+	}{
+		{
+			name:           "0 bytes",
+			n:              "0",
+			expectedStatus: http.StatusOK,
+			expectedLength: 0,
+		},
+		{
+			name:           "10 bytes",
+			n:              "10",
+			expectedStatus: http.StatusOK,
+			expectedLength: 10,
+		},
+		{
+			name:           "1024 bytes",
+			n:              "1024",
+			expectedStatus: http.StatusOK,
+			expectedLength: 1024,
+		},
+		{
+			name:           "negative number returns 400",
+			n:              "-1",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "over max returns 400",
+			n:              "102401",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "non-numeric returns 400",
+			n:              "abc",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/bytes/{n}", BytesHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/bytes/"+tt.n, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedStatus == http.StatusOK {
+				if len(rec.Body.Bytes()) != tt.expectedLength {
+					t.Errorf("expected %d bytes, got %d", tt.expectedLength, len(rec.Body.Bytes()))
+				}
+
+				contentType := rec.Header().Get("Content-Type")
+				if contentType != "application/octet-stream" {
+					t.Errorf("expected Content-Type application/octet-stream, got %s", contentType)
+				}
+			}
+		})
+	}
+}
+
+func TestBytesHandlerRandomness(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/bytes/{n}", BytesHandler)
+
+	// Generate two responses and ensure they're different (with high probability)
+	req1 := httptest.NewRequest(http.MethodGet, "/bytes/100", nil)
+	rec1 := httptest.NewRecorder()
+	r.ServeHTTP(rec1, req1)
+
+	req2 := httptest.NewRequest(http.MethodGet, "/bytes/100", nil)
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+
+	// Compare the two responses
+	if rec1.Body.String() == rec2.Body.String() {
+		t.Error("expected different random bytes, got identical responses")
+	}
+}

--- a/echo-http/handlers/compression.go
+++ b/echo-http/handlers/compression.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+
+	"github.com/andybalholm/brotli"
+)
+
+type CompressionResponse struct {
+	Compressed bool              `json:"compressed"`
+	Method     string            `json:"method"`
+	Origin     string            `json:"origin"`
+	Headers    map[string]string `json:"headers"`
+}
+
+// GzipHandler returns a gzip-compressed response.
+// GET /gzip - Return gzip-compressed response
+func GzipHandler(w http.ResponseWriter, r *http.Request) {
+	response := CompressionResponse{
+		Compressed: true,
+		Method:     "gzip",
+		Origin:     getClientIP(r),
+		Headers:    make(map[string]string),
+	}
+
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			response.Headers[key] = values[0]
+		}
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(jsonData); err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+	if err := gz.Close(); err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Encoding", "gzip")
+	_, _ = w.Write(buf.Bytes())
+}
+
+// DeflateHandler returns a deflate-compressed response.
+// GET /deflate - Return deflate-compressed response
+func DeflateHandler(w http.ResponseWriter, r *http.Request) {
+	response := CompressionResponse{
+		Compressed: true,
+		Method:     "deflate",
+		Origin:     getClientIP(r),
+		Headers:    make(map[string]string),
+	}
+
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			response.Headers[key] = values[0]
+		}
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	if err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+	if _, err := fw.Write(jsonData); err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+	if err := fw.Close(); err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Encoding", "deflate")
+	_, _ = w.Write(buf.Bytes())
+}
+
+// BrotliHandler returns a brotli-compressed response.
+// GET /brotli - Return brotli-compressed response
+func BrotliHandler(w http.ResponseWriter, r *http.Request) {
+	response := CompressionResponse{
+		Compressed: true,
+		Method:     "br",
+		Origin:     getClientIP(r),
+		Headers:    make(map[string]string),
+	}
+
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			response.Headers[key] = values[0]
+		}
+	}
+
+	jsonData, err := json.Marshal(response)
+	if err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	if _, err := bw.Write(jsonData); err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+	if err := bw.Close(); err != nil {
+		http.Error(w, "Failed to compress response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Encoding", "br")
+	_, _ = w.Write(buf.Bytes())
+}

--- a/echo-http/handlers/compression_test.go
+++ b/echo-http/handlers/compression_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestGzipHandler(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/gzip", GzipHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/gzip", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	contentEncoding := rec.Header().Get("Content-Encoding")
+	if contentEncoding != "gzip" {
+		t.Errorf("expected Content-Encoding gzip, got %s", contentEncoding)
+	}
+
+	// Decompress and verify
+	gz, err := gzip.NewReader(bytes.NewReader(rec.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	decompressed, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("failed to decompress: %v", err)
+	}
+
+	var response CompressionResponse
+	if err := json.Unmarshal(decompressed, &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Compressed {
+		t.Error("expected compressed to be true")
+	}
+	if response.Method != "gzip" {
+		t.Errorf("expected method gzip, got %s", response.Method)
+	}
+	if response.Origin != "192.168.1.100" {
+		t.Errorf("expected origin 192.168.1.100, got %s", response.Origin)
+	}
+}
+
+func TestDeflateHandler(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/deflate", DeflateHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/deflate", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	contentEncoding := rec.Header().Get("Content-Encoding")
+	if contentEncoding != "deflate" {
+		t.Errorf("expected Content-Encoding deflate, got %s", contentEncoding)
+	}
+
+	// Decompress and verify
+	fr := flate.NewReader(bytes.NewReader(rec.Body.Bytes()))
+	defer func() { _ = fr.Close() }()
+
+	decompressed, err := io.ReadAll(fr)
+	if err != nil {
+		t.Fatalf("failed to decompress: %v", err)
+	}
+
+	var response CompressionResponse
+	if err := json.Unmarshal(decompressed, &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Compressed {
+		t.Error("expected compressed to be true")
+	}
+	if response.Method != "deflate" {
+		t.Errorf("expected method deflate, got %s", response.Method)
+	}
+}
+
+func TestBrotliHandler(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/brotli", BrotliHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/brotli", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	contentEncoding := rec.Header().Get("Content-Encoding")
+	if contentEncoding != "br" {
+		t.Errorf("expected Content-Encoding br, got %s", contentEncoding)
+	}
+
+	// Decompress and verify
+	br := brotli.NewReader(bytes.NewReader(rec.Body.Bytes()))
+
+	decompressed, err := io.ReadAll(br)
+	if err != nil {
+		t.Fatalf("failed to decompress: %v", err)
+	}
+
+	var response CompressionResponse
+	if err := json.Unmarshal(decompressed, &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Compressed {
+		t.Error("expected compressed to be true")
+	}
+	if response.Method != "br" {
+		t.Errorf("expected method br, got %s", response.Method)
+	}
+}

--- a/echo-http/handlers/cookies.go
+++ b/echo-http/handlers/cookies.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+type CookiesResponse struct {
+	Cookies map[string]string `json:"cookies"`
+}
+
+// CookiesHandler returns all cookies sent with the request.
+// GET /cookies - Echo request cookies
+func CookiesHandler(w http.ResponseWriter, r *http.Request) {
+	cookies := make(map[string]string)
+	for _, cookie := range r.Cookies() {
+		cookies[cookie.Name] = cookie.Value
+	}
+
+	response := CookiesResponse{
+		Cookies: cookies,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// CookiesSetHandler sets cookies from query parameters and redirects to /cookies.
+// GET /cookies/set?{name}={value}&... - Set cookies and redirect to /cookies
+func CookiesSetHandler(w http.ResponseWriter, r *http.Request) {
+	for name, values := range r.URL.Query() {
+		if len(values) > 0 {
+			cookie := &http.Cookie{
+				Name:     name,
+				Value:    values[0],
+				Path:     "/",
+				HttpOnly: true,
+				SameSite: http.SameSiteLaxMode,
+			}
+			http.SetCookie(w, cookie)
+		}
+	}
+
+	http.Redirect(w, r, "/cookies", http.StatusFound)
+}
+
+// CookiesDeleteHandler deletes cookies specified in query parameters.
+// GET /cookies/delete?{name}&... - Delete specified cookies and redirect to /cookies
+func CookiesDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	for name := range r.URL.Query() {
+		cookie := &http.Cookie{
+			Name:     name,
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			Expires:  time.Unix(0, 0),
+			HttpOnly: true,
+		}
+		http.SetCookie(w, cookie)
+	}
+
+	http.Redirect(w, r, "/cookies", http.StatusFound)
+}

--- a/echo-http/handlers/cookies_test.go
+++ b/echo-http/handlers/cookies_test.go
@@ -1,0 +1,182 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestCookiesHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		cookies         []*http.Cookie
+		expectedCookies map[string]string
+	}{
+		{
+			name:            "no cookies",
+			cookies:         nil,
+			expectedCookies: map[string]string{},
+		},
+		{
+			name: "single cookie",
+			cookies: []*http.Cookie{
+				{Name: "session", Value: "abc123"},
+			},
+			expectedCookies: map[string]string{"session": "abc123"},
+		},
+		{
+			name: "multiple cookies",
+			cookies: []*http.Cookie{
+				{Name: "session", Value: "abc123"},
+				{Name: "user", Value: "testuser"},
+			},
+			expectedCookies: map[string]string{"session": "abc123", "user": "testuser"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/cookies", CookiesHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/cookies", nil)
+			for _, cookie := range tt.cookies {
+				req.AddCookie(cookie)
+			}
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+			}
+
+			var response CookiesResponse
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if len(response.Cookies) != len(tt.expectedCookies) {
+				t.Errorf("expected %d cookies, got %d", len(tt.expectedCookies), len(response.Cookies))
+			}
+
+			for name, value := range tt.expectedCookies {
+				if response.Cookies[name] != value {
+					t.Errorf("expected cookie %s=%s, got %s", name, value, response.Cookies[name])
+				}
+			}
+		})
+	}
+}
+
+func TestCookiesSetHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		query           string
+		expectedCookies []string
+	}{
+		{
+			name:            "set single cookie",
+			query:           "?session=abc123",
+			expectedCookies: []string{"session"},
+		},
+		{
+			name:            "set multiple cookies",
+			query:           "?session=abc123&user=testuser",
+			expectedCookies: []string{"session", "user"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/cookies/set", CookiesSetHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/cookies/set"+tt.query, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusFound {
+				t.Errorf("expected status %d, got %d", http.StatusFound, rec.Code)
+			}
+
+			location := rec.Header().Get("Location")
+			if location != "/cookies" {
+				t.Errorf("expected redirect to /cookies, got %s", location)
+			}
+
+			cookies := rec.Result().Cookies()
+			cookieNames := make(map[string]bool)
+			for _, cookie := range cookies {
+				cookieNames[cookie.Name] = true
+			}
+
+			for _, expected := range tt.expectedCookies {
+				if !cookieNames[expected] {
+					t.Errorf("expected cookie %s to be set", expected)
+				}
+			}
+		})
+	}
+}
+
+func TestCookiesDeleteHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		query           string
+		expectedDeleted []string
+	}{
+		{
+			name:            "delete single cookie",
+			query:           "?session",
+			expectedDeleted: []string{"session"},
+		},
+		{
+			name:            "delete multiple cookies",
+			query:           "?session&user",
+			expectedDeleted: []string{"session", "user"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/cookies/delete", CookiesDeleteHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/cookies/delete"+tt.query, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusFound {
+				t.Errorf("expected status %d, got %d", http.StatusFound, rec.Code)
+			}
+
+			location := rec.Header().Get("Location")
+			if location != "/cookies" {
+				t.Errorf("expected redirect to /cookies, got %s", location)
+			}
+
+			cookies := rec.Result().Cookies()
+			for _, cookie := range cookies {
+				found := false
+				for _, expected := range tt.expectedDeleted {
+					if cookie.Name == expected {
+						found = true
+						if cookie.MaxAge != -1 {
+							t.Errorf("expected cookie %s to have MaxAge -1, got %d", cookie.Name, cookie.MaxAge)
+						}
+						break
+					}
+				}
+				if !found {
+					t.Errorf("unexpected cookie in response: %s", cookie.Name)
+				}
+			}
+		})
+	}
+}

--- a/echo-http/handlers/redirect.go
+++ b/echo-http/handlers/redirect.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	maxRedirectCount = 100
+)
+
+// RedirectHandler redirects n times before returning a final response.
+// GET /redirect/{n} - Redirect n times, then return 200 OK
+func RedirectHandler(w http.ResponseWriter, r *http.Request) {
+	nStr := chi.URLParam(r, "n")
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n < 0 || n > maxRedirectCount {
+		http.Error(w, fmt.Sprintf("Invalid redirect count (must be 0-%d)", maxRedirectCount), http.StatusBadRequest)
+		return
+	}
+
+	if n == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"redirected":true}`))
+		return
+	}
+
+	location := fmt.Sprintf("/redirect/%d", n-1)
+	http.Redirect(w, r, location, http.StatusFound)
+}
+
+// RedirectToHandler redirects to a specified URL.
+// GET /redirect-to?url={url}&status_code={code}
+func RedirectToHandler(w http.ResponseWriter, r *http.Request) {
+	targetURL := r.URL.Query().Get("url")
+	if targetURL == "" {
+		http.Error(w, "Missing required parameter: url", http.StatusBadRequest)
+		return
+	}
+
+	statusCode := http.StatusFound // default 302
+	if codeStr := r.URL.Query().Get("status_code"); codeStr != "" {
+		code, err := strconv.Atoi(codeStr)
+		if err != nil {
+			http.Error(w, "Invalid status_code", http.StatusBadRequest)
+			return
+		}
+		// Only allow redirect status codes
+		if code != http.StatusMovedPermanently && // 301
+			code != http.StatusFound && // 302
+			code != http.StatusSeeOther && // 303
+			code != http.StatusTemporaryRedirect && // 307
+			code != http.StatusPermanentRedirect { // 308
+			http.Error(w, "status_code must be a redirect code (301, 302, 303, 307, 308)", http.StatusBadRequest)
+			return
+		}
+		statusCode = code
+	}
+
+	http.Redirect(w, r, targetURL, statusCode)
+}
+
+// AbsoluteRedirectHandler redirects n times using absolute URLs.
+// GET /absolute-redirect/{n} - Redirect n times with absolute URLs
+func AbsoluteRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	nStr := chi.URLParam(r, "n")
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n < 0 || n > maxRedirectCount {
+		http.Error(w, fmt.Sprintf("Invalid redirect count (must be 0-%d)", maxRedirectCount), http.StatusBadRequest)
+		return
+	}
+
+	if n == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"redirected":true}`))
+		return
+	}
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if fwdProto := r.Header.Get("X-Forwarded-Proto"); fwdProto != "" {
+		scheme = fwdProto
+	}
+
+	host := r.Host
+	location := fmt.Sprintf("%s://%s/absolute-redirect/%d", scheme, host, n-1)
+	http.Redirect(w, r, location, http.StatusFound)
+}
+
+// RelativeRedirectHandler redirects n times using relative URLs.
+// GET /relative-redirect/{n} - Redirect n times with relative URLs
+func RelativeRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	nStr := chi.URLParam(r, "n")
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n < 0 || n > maxRedirectCount {
+		http.Error(w, fmt.Sprintf("Invalid redirect count (must be 0-%d)", maxRedirectCount), http.StatusBadRequest)
+		return
+	}
+
+	if n == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"redirected":true}`))
+		return
+	}
+
+	location := fmt.Sprintf("/relative-redirect/%d", n-1)
+	http.Redirect(w, r, location, http.StatusFound)
+}

--- a/echo-http/handlers/redirect_test.go
+++ b/echo-http/handlers/redirect_test.go
@@ -1,0 +1,235 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRedirectHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		n                string
+		expectedStatus   int
+		expectedLocation string
+	}{
+		{
+			name:           "0 redirects returns success",
+			n:              "0",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:             "1 redirect",
+			n:                "1",
+			expectedStatus:   http.StatusFound,
+			expectedLocation: "/redirect/0",
+		},
+		{
+			name:             "5 redirects",
+			n:                "5",
+			expectedStatus:   http.StatusFound,
+			expectedLocation: "/redirect/4",
+		},
+		{
+			name:           "negative number returns 400",
+			n:              "-1",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "over max returns 400",
+			n:              "101",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "non-numeric returns 400",
+			n:              "abc",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/redirect/{n}", RedirectHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/redirect/"+tt.n, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedLocation != "" {
+				location := rec.Header().Get("Location")
+				if location != tt.expectedLocation {
+					t.Errorf("expected location %q, got %q", tt.expectedLocation, location)
+				}
+			}
+		})
+	}
+}
+
+func TestRedirectToHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		query            string
+		expectedStatus   int
+		expectedLocation string
+	}{
+		{
+			name:             "redirect to URL with default status",
+			query:            "?url=https://example.com",
+			expectedStatus:   http.StatusFound,
+			expectedLocation: "https://example.com",
+		},
+		{
+			name:             "redirect with 301",
+			query:            "?url=https://example.com&status_code=301",
+			expectedStatus:   http.StatusMovedPermanently,
+			expectedLocation: "https://example.com",
+		},
+		{
+			name:             "redirect with 307",
+			query:            "?url=https://example.com&status_code=307",
+			expectedStatus:   http.StatusTemporaryRedirect,
+			expectedLocation: "https://example.com",
+		},
+		{
+			name:             "redirect with 308",
+			query:            "?url=https://example.com&status_code=308",
+			expectedStatus:   http.StatusPermanentRedirect,
+			expectedLocation: "https://example.com",
+		},
+		{
+			name:           "missing url returns 400",
+			query:          "",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "invalid status_code returns 400",
+			query:          "?url=https://example.com&status_code=abc",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "non-redirect status_code returns 400",
+			query:          "?url=https://example.com&status_code=200",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/redirect-to", RedirectToHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/redirect-to"+tt.query, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedLocation != "" {
+				location := rec.Header().Get("Location")
+				if location != tt.expectedLocation {
+					t.Errorf("expected location %q, got %q", tt.expectedLocation, location)
+				}
+			}
+		})
+	}
+}
+
+func TestAbsoluteRedirectHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		n                string
+		expectedStatus   int
+		expectedLocation string
+	}{
+		{
+			name:           "0 redirects returns success",
+			n:              "0",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:             "1 redirect with absolute URL",
+			n:                "1",
+			expectedStatus:   http.StatusFound,
+			expectedLocation: "http://example.com/absolute-redirect/0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/absolute-redirect/{n}", AbsoluteRedirectHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/absolute-redirect/"+tt.n, nil)
+			req.Host = "example.com"
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedLocation != "" {
+				location := rec.Header().Get("Location")
+				if location != tt.expectedLocation {
+					t.Errorf("expected location %q, got %q", tt.expectedLocation, location)
+				}
+			}
+		})
+	}
+}
+
+func TestRelativeRedirectHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		n                string
+		expectedStatus   int
+		expectedLocation string
+	}{
+		{
+			name:           "0 redirects returns success",
+			n:              "0",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name:             "1 redirect with relative URL",
+			n:                "1",
+			expectedStatus:   http.StatusFound,
+			expectedLocation: "/relative-redirect/0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/relative-redirect/{n}", RelativeRedirectHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/relative-redirect/"+tt.n, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedLocation != "" {
+				location := rec.Header().Get("Location")
+				if location != tt.expectedLocation {
+					t.Errorf("expected location %q, got %q", tt.expectedLocation, location)
+				}
+			}
+		})
+	}
+}

--- a/echo-http/handlers/stream.go
+++ b/echo-http/handlers/stream.go
@@ -1,0 +1,138 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	maxStreamLines  = 100
+	maxDripBytes    = 10 * 1024 // 10KB
+	maxDripDuration = 60        // 60 seconds
+)
+
+type StreamLine struct {
+	ID      int               `json:"id"`
+	URL     string            `json:"url"`
+	Args    map[string]string `json:"args"`
+	Headers map[string]string `json:"headers"`
+	Origin  string            `json:"origin"`
+}
+
+// StreamHandler streams n lines of JSON data.
+// GET /stream/{n} - Stream n lines of data (chunked transfer)
+func StreamHandler(w http.ResponseWriter, r *http.Request) {
+	nStr := chi.URLParam(r, "n")
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n < 0 || n > maxStreamLines {
+		http.Error(w, fmt.Sprintf("Invalid line count (must be 0-%d)", maxStreamLines), http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Transfer-Encoding", "chunked")
+
+	args := make(map[string]string)
+	for key, values := range r.URL.Query() {
+		if len(values) > 0 {
+			args[key] = values[0]
+		}
+	}
+
+	headers := make(map[string]string)
+	for key, values := range r.Header {
+		if len(values) > 0 {
+			headers[key] = values[0]
+		}
+	}
+
+	origin := getClientIP(r)
+
+	for i := range n {
+		line := StreamLine{
+			ID:      i,
+			URL:     r.URL.RequestURI(),
+			Args:    args,
+			Headers: headers,
+			Origin:  origin,
+		}
+
+		data, _ := json.Marshal(line)
+		_, _ = w.Write(data)
+		_, _ = w.Write([]byte("\n"))
+		flusher.Flush()
+	}
+}
+
+// DripHandler drips data over a specified duration.
+// GET /drip?duration={s}&numbytes={n}&delay={s} - Drip data over duration
+func DripHandler(w http.ResponseWriter, r *http.Request) {
+	duration := 2.0 // default 2 seconds
+	if d := r.URL.Query().Get("duration"); d != "" {
+		parsed, err := strconv.ParseFloat(d, 64)
+		if err != nil || parsed < 0 || parsed > float64(maxDripDuration) {
+			http.Error(w, fmt.Sprintf("Invalid duration (must be 0-%d seconds)", maxDripDuration), http.StatusBadRequest)
+			return
+		}
+		duration = parsed
+	}
+
+	numBytes := 10 // default 10 bytes
+	if n := r.URL.Query().Get("numbytes"); n != "" {
+		parsed, err := strconv.Atoi(n)
+		if err != nil || parsed < 0 || parsed > maxDripBytes {
+			http.Error(w, fmt.Sprintf("Invalid numbytes (must be 0-%d)", maxDripBytes), http.StatusBadRequest)
+			return
+		}
+		numBytes = parsed
+	}
+
+	delay := 0.0 // default no initial delay
+	if d := r.URL.Query().Get("delay"); d != "" {
+		parsed, err := strconv.ParseFloat(d, 64)
+		if err != nil || parsed < 0 || parsed > float64(maxDripDuration) {
+			http.Error(w, fmt.Sprintf("Invalid delay (must be 0-%d seconds)", maxDripDuration), http.StatusBadRequest)
+			return
+		}
+		delay = parsed
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Initial delay
+	if delay > 0 {
+		time.Sleep(time.Duration(delay * float64(time.Second)))
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+
+	if numBytes == 0 {
+		return
+	}
+
+	// Calculate interval between bytes
+	interval := time.Duration(duration * float64(time.Second) / float64(numBytes))
+
+	for range numBytes {
+		_, _ = w.Write([]byte("*"))
+		flusher.Flush()
+		if interval > 0 {
+			time.Sleep(interval)
+		}
+	}
+}

--- a/echo-http/handlers/stream_test.go
+++ b/echo-http/handlers/stream_test.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestStreamHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		n              string
+		expectedStatus int
+		expectedLines  int
+	}{
+		{
+			name:           "0 lines",
+			n:              "0",
+			expectedStatus: http.StatusOK,
+			expectedLines:  0,
+		},
+		{
+			name:           "5 lines",
+			n:              "5",
+			expectedStatus: http.StatusOK,
+			expectedLines:  5,
+		},
+		{
+			name:           "negative number returns 400",
+			n:              "-1",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "over max returns 400",
+			n:              "101",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "non-numeric returns 400",
+			n:              "abc",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/stream/{n}", StreamHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/stream/"+tt.n, nil)
+			req.RemoteAddr = "192.168.1.100:12345"
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedStatus == http.StatusOK && tt.expectedLines > 0 {
+				scanner := bufio.NewScanner(rec.Body)
+				lineCount := 0
+				for scanner.Scan() {
+					line := scanner.Text()
+					if line == "" {
+						continue
+					}
+
+					var streamLine StreamLine
+					if err := json.Unmarshal([]byte(line), &streamLine); err != nil {
+						t.Errorf("failed to parse line %d: %v", lineCount, err)
+						continue
+					}
+
+					if streamLine.ID != lineCount {
+						t.Errorf("expected ID %d, got %d", lineCount, streamLine.ID)
+					}
+
+					lineCount++
+				}
+
+				if lineCount != tt.expectedLines {
+					t.Errorf("expected %d lines, got %d", tt.expectedLines, lineCount)
+				}
+			}
+		})
+	}
+}
+
+func TestStreamHandlerContent(t *testing.T) {
+	r := chi.NewRouter()
+	r.Get("/stream/{n}", StreamHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/1?foo=bar", nil)
+	req.Header.Set("X-Custom-Header", "test-value")
+	req.RemoteAddr = "192.168.1.100:12345"
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	var streamLine StreamLine
+	if err := json.Unmarshal([]byte(strings.TrimSpace(rec.Body.String())), &streamLine); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if streamLine.Args["foo"] != "bar" {
+		t.Errorf("expected foo=bar, got %s", streamLine.Args["foo"])
+	}
+
+	if streamLine.Headers["X-Custom-Header"] != "test-value" {
+		t.Errorf("expected X-Custom-Header=test-value, got %s", streamLine.Headers["X-Custom-Header"])
+	}
+
+	if streamLine.Origin != "192.168.1.100" {
+		t.Errorf("expected origin 192.168.1.100, got %s", streamLine.Origin)
+	}
+}
+
+func TestDripHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          string
+		expectedStatus int
+		expectedBytes  int
+	}{
+		{
+			name:           "default values",
+			query:          "",
+			expectedStatus: http.StatusOK,
+			expectedBytes:  10,
+		},
+		{
+			name:           "custom numbytes",
+			query:          "?numbytes=5",
+			expectedStatus: http.StatusOK,
+			expectedBytes:  5,
+		},
+		{
+			name:           "zero bytes",
+			query:          "?numbytes=0",
+			expectedStatus: http.StatusOK,
+			expectedBytes:  0,
+		},
+		{
+			name:           "zero duration",
+			query:          "?duration=0&numbytes=5",
+			expectedStatus: http.StatusOK,
+			expectedBytes:  5,
+		},
+		{
+			name:           "invalid duration",
+			query:          "?duration=abc",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "invalid numbytes",
+			query:          "?numbytes=abc",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "negative duration",
+			query:          "?duration=-1",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "over max numbytes",
+			query:          "?numbytes=10241",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "over max duration",
+			query:          "?duration=61",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/drip", DripHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/drip"+tt.query, nil)
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, rec.Code)
+			}
+
+			if tt.expectedStatus == http.StatusOK {
+				if len(rec.Body.Bytes()) != tt.expectedBytes {
+					t.Errorf("expected %d bytes, got %d", tt.expectedBytes, len(rec.Body.Bytes()))
+				}
+			}
+		})
+	}
+}

--- a/echo-http/handlers/utility.go
+++ b/echo-http/handlers/utility.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type IPResponse struct {
+	Origin string `json:"origin"`
+}
+
+type UserAgentResponse struct {
+	UserAgent string `json:"user-agent"`
+}
+
+// IPHandler returns the client's IP address.
+// GET /ip - Return client IP address
+func IPHandler(w http.ResponseWriter, r *http.Request) {
+	response := IPResponse{
+		Origin: getClientIP(r),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// UserAgentHandler returns the User-Agent header.
+// GET /user-agent - Return User-Agent header
+func UserAgentHandler(w http.ResponseWriter, r *http.Request) {
+	response := UserAgentResponse{
+		UserAgent: r.Header.Get("User-Agent"),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// getClientIP extracts the client IP address from the request.
+// It checks X-Forwarded-For, X-Real-IP headers before falling back to RemoteAddr.
+func getClientIP(r *http.Request) string {
+	// Check X-Forwarded-For header (may contain multiple IPs)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		ips := strings.Split(xff, ",")
+		if len(ips) > 0 {
+			return strings.TrimSpace(ips[0])
+		}
+	}
+
+	// Check X-Real-IP header
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	// Fall back to RemoteAddr
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}

--- a/echo-http/handlers/utility_test.go
+++ b/echo-http/handlers/utility_test.go
@@ -1,0 +1,171 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestIPHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		remoteAddr     string
+		xForwardedFor  string
+		xRealIP        string
+		expectedOrigin string
+	}{
+		{
+			name:           "from RemoteAddr",
+			remoteAddr:     "192.168.1.100:12345",
+			expectedOrigin: "192.168.1.100",
+		},
+		{
+			name:           "from X-Forwarded-For",
+			remoteAddr:     "10.0.0.1:12345",
+			xForwardedFor:  "203.0.113.50",
+			expectedOrigin: "203.0.113.50",
+		},
+		{
+			name:           "from X-Forwarded-For with multiple IPs",
+			remoteAddr:     "10.0.0.1:12345",
+			xForwardedFor:  "203.0.113.50, 70.41.3.18, 150.172.238.178",
+			expectedOrigin: "203.0.113.50",
+		},
+		{
+			name:           "from X-Real-IP",
+			remoteAddr:     "10.0.0.1:12345",
+			xRealIP:        "203.0.113.100",
+			expectedOrigin: "203.0.113.100",
+		},
+		{
+			name:           "X-Forwarded-For takes precedence over X-Real-IP",
+			remoteAddr:     "10.0.0.1:12345",
+			xForwardedFor:  "203.0.113.50",
+			xRealIP:        "203.0.113.100",
+			expectedOrigin: "203.0.113.50",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/ip", IPHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/ip", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.xForwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", tt.xForwardedFor)
+			}
+			if tt.xRealIP != "" {
+				req.Header.Set("X-Real-IP", tt.xRealIP)
+			}
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+			}
+
+			var response IPResponse
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if response.Origin != tt.expectedOrigin {
+				t.Errorf("expected origin %q, got %q", tt.expectedOrigin, response.Origin)
+			}
+		})
+	}
+}
+
+func TestUserAgentHandler(t *testing.T) {
+	tests := []struct {
+		name              string
+		userAgent         string
+		expectedUserAgent string
+	}{
+		{
+			name:              "standard user agent",
+			userAgent:         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+			expectedUserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+		},
+		{
+			name:              "curl user agent",
+			userAgent:         "curl/7.79.1",
+			expectedUserAgent: "curl/7.79.1",
+		},
+		{
+			name:              "empty user agent",
+			userAgent:         "",
+			expectedUserAgent: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			r.Get("/user-agent", UserAgentHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/user-agent", nil)
+			if tt.userAgent != "" {
+				req.Header.Set("User-Agent", tt.userAgent)
+			}
+			rec := httptest.NewRecorder()
+
+			r.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+			}
+
+			var response UserAgentResponse
+			if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if response.UserAgent != tt.expectedUserAgent {
+				t.Errorf("expected user-agent %q, got %q", tt.expectedUserAgent, response.UserAgent)
+			}
+		})
+	}
+}
+
+func TestGetClientIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		expectedIP string
+	}{
+		{
+			name:       "with port",
+			remoteAddr: "192.168.1.1:8080",
+			expectedIP: "192.168.1.1",
+		},
+		{
+			name:       "without port",
+			remoteAddr: "192.168.1.1",
+			expectedIP: "192.168.1.1",
+		},
+		{
+			name:       "IPv6 with port",
+			remoteAddr: "[::1]:8080",
+			expectedIP: "::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+
+			ip := getClientIP(req)
+			if ip != tt.expectedIP {
+				t.Errorf("expected IP %q, got %q", tt.expectedIP, ip)
+			}
+		})
+	}
+}

--- a/echo-http/main.go
+++ b/echo-http/main.go
@@ -24,10 +24,48 @@ func main() {
 	r.Patch("/patch", handlers.EchoHandler)
 	r.Delete("/delete", handlers.EchoHandler)
 
+	// Anything endpoint - echoes any request
+	r.HandleFunc("/anything", handlers.AnythingHandler)
+	r.HandleFunc("/anything/*", handlers.AnythingHandler)
+
 	// Utility endpoints
 	r.Get("/headers", handlers.HeadersHandler)
-	r.Get("/status/{code}", handlers.StatusHandler)
+	r.Get("/ip", handlers.IPHandler)
+	r.Get("/user-agent", handlers.UserAgentHandler)
+
+	// Status endpoint - support all HTTP methods
+	r.HandleFunc("/status/{code}", handlers.StatusHandler)
+
+	// Delay endpoint
 	r.Get("/delay/{seconds}", handlers.DelayHandler)
+
+	// Redirect endpoints
+	r.Get("/redirect/{n}", handlers.RedirectHandler)
+	r.Get("/redirect-to", handlers.RedirectToHandler)
+	r.Get("/absolute-redirect/{n}", handlers.AbsoluteRedirectHandler)
+	r.Get("/relative-redirect/{n}", handlers.RelativeRedirectHandler)
+
+	// Authentication endpoints
+	r.Get("/basic-auth/{user}/{pass}", handlers.BasicAuthHandler)
+	r.Get("/hidden-basic-auth/{user}/{pass}", handlers.HiddenBasicAuthHandler)
+	r.Get("/bearer", handlers.BearerHandler)
+
+	// Cookie endpoints
+	r.Get("/cookies", handlers.CookiesHandler)
+	r.Get("/cookies/set", handlers.CookiesSetHandler)
+	r.Get("/cookies/delete", handlers.CookiesDeleteHandler)
+
+	// Binary data endpoints
+	r.Get("/bytes/{n}", handlers.BytesHandler)
+
+	// Streaming endpoints
+	r.Get("/stream/{n}", handlers.StreamHandler)
+	r.Get("/drip", handlers.DripHandler)
+
+	// Compression endpoints
+	r.Get("/gzip", handlers.GzipHandler)
+	r.Get("/deflate", handlers.DeflateHandler)
+	r.Get("/brotli", handlers.BrotliHandler)
 
 	// Health check endpoint
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Add redirect testing endpoints: `/redirect/{n}`, `/redirect-to`, `/absolute-redirect/{n}`, `/relative-redirect/{n}`
- Add authentication endpoints: `/basic-auth/{user}/{pass}`, `/hidden-basic-auth/{user}/{pass}`, `/bearer`
- Add cookie handling: `/cookies`, `/cookies/set`, `/cookies/delete`
- Add response manipulation: `/bytes/{n}`, `/stream/{n}`, `/drip`
- Add compression: `/gzip`, `/deflate`, `/brotli`
- Add utility: `/anything`, `/ip`, `/user-agent`

Inspired by [httpbin.org](https://httpbin.org/) for comprehensive HTTP client testing.

Closes #4

## Test plan

- [x] All handlers have corresponding unit tests
- [x] `just echo-http::lint` passes (0 issues)
- [x] `just echo-http::test` passes (50+ tests)
- [x] `just echo-http::build` succeeds