### PR TITLE
feat(echo-grpc): Add comprehensive gRPC testing RPCs

### DIFF
--- a/echo-grpc/docs/api.md
+++ b/echo-grpc/docs/api.md
@@ -1,6 +1,8 @@
 # echo-grpc API Reference
 
-## Service Definition
+## Services
+
+### Echo Service (echo.v1.Echo)
 
 ```protobuf
 package echo.v1;
@@ -11,10 +13,34 @@ service Echo {
   rpc EchoWithDelay (EchoWithDelayRequest) returns (EchoResponse);
   rpc EchoError (EchoErrorRequest) returns (EchoResponse);
 
+  // Metadata/Headers RPCs
+  rpc EchoRequestMetadata (EchoRequestMetadataRequest) returns (EchoRequestMetadataResponse);
+  rpc EchoWithTrailers (EchoWithTrailersRequest) returns (EchoResponse);
+
+  // Payload Testing RPCs
+  rpc EchoLargePayload (EchoLargePayloadRequest) returns (EchoLargePayloadResponse);
+
+  // Deadline/Timeout RPCs
+  rpc EchoDeadline (EchoDeadlineRequest) returns (EchoDeadlineResponse);
+
+  // Error Scenarios RPCs
+  rpc EchoErrorWithDetails (EchoErrorWithDetailsRequest) returns (EchoResponse);
+
   // Streaming RPCs
   rpc ServerStream (ServerStreamRequest) returns (stream EchoResponse);
   rpc ClientStream (stream EchoRequest) returns (EchoResponse);
   rpc BidirectionalStream (stream EchoRequest) returns (stream EchoResponse);
+}
+```
+
+### Health Service (grpc.health.v1.Health)
+
+Standard gRPC health checking protocol.
+
+```protobuf
+service Health {
+  rpc Check (HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch (HealthCheckRequest) returns (stream HealthCheckResponse);
 }
 ```
 
@@ -92,6 +118,146 @@ message ServerStreamRequest {
 | `count`       | int32  | Number of responses to stream    |
 | `interval_ms` | int32  | Interval between responses       |
 
+### EchoRequestMetadataRequest
+
+```protobuf
+message EchoRequestMetadataRequest {
+  repeated string keys = 1;
+}
+```
+
+| Field  | Type            | Description                                  |
+| ------ | --------------- | -------------------------------------------- |
+| `keys` | repeated string | Filter to specific keys (empty = return all) |
+
+### EchoRequestMetadataResponse
+
+```protobuf
+message EchoRequestMetadataResponse {
+  map<string, MetadataValues> metadata = 1;
+}
+
+message MetadataValues {
+  repeated string values = 1;
+}
+```
+
+| Field      | Type                        | Description                    |
+| ---------- | --------------------------- | ------------------------------ |
+| `metadata` | map<string, MetadataValues> | All request metadata as values |
+
+### EchoWithTrailersRequest
+
+```protobuf
+message EchoWithTrailersRequest {
+  string message = 1;
+  map<string, string> trailers = 2;
+}
+```
+
+| Field      | Type               | Description                    |
+| ---------- | ------------------ | ------------------------------ |
+| `message`  | string             | Message to echo back           |
+| `trailers` | map<string,string> | Trailers to send with response |
+
+### EchoLargePayloadRequest
+
+```protobuf
+message EchoLargePayloadRequest {
+  int32 size_bytes = 1;
+  string pattern = 2;
+}
+```
+
+| Field        | Type   | Description                          |
+| ------------ | ------ | ------------------------------------ |
+| `size_bytes` | int32  | Size of payload to return (max 10MB) |
+| `pattern`    | string | Pattern to repeat (default: 'X')     |
+
+### EchoLargePayloadResponse
+
+```protobuf
+message EchoLargePayloadResponse {
+  bytes payload = 1;
+  int32 actual_size = 2;
+}
+```
+
+| Field         | Type  | Description                |
+| ------------- | ----- | -------------------------- |
+| `payload`     | bytes | Generated payload          |
+| `actual_size` | int32 | Actual size of the payload |
+
+### EchoDeadlineRequest
+
+```protobuf
+message EchoDeadlineRequest {
+  string message = 1;
+}
+```
+
+| Field     | Type   | Description          |
+| --------- | ------ | -------------------- |
+| `message` | string | Message to echo back |
+
+### EchoDeadlineResponse
+
+```protobuf
+message EchoDeadlineResponse {
+  string message = 1;
+  int64 deadline_remaining_ms = 2;
+  bool has_deadline = 3;
+}
+```
+
+| Field                   | Type   | Description                     |
+| ----------------------- | ------ | ------------------------------- |
+| `message`               | string | Echoed message                  |
+| `deadline_remaining_ms` | int64  | Remaining deadline (-1 if none) |
+| `has_deadline`          | bool   | Whether a deadline was set      |
+
+### EchoErrorWithDetailsRequest
+
+```protobuf
+message EchoErrorWithDetailsRequest {
+  int32 code = 1;
+  string message = 2;
+  repeated ErrorDetail details = 3;
+}
+
+message ErrorDetail {
+  string type = 1;
+  repeated FieldViolation field_violations = 2;
+  int64 retry_delay_ms = 3;
+  repeated string stack_entries = 4;
+  string debug_detail = 5;
+  repeated QuotaViolation quota_violations = 6;
+}
+
+message FieldViolation {
+  string field = 1;
+  string description = 2;
+}
+
+message QuotaViolation {
+  string subject = 1;
+  string description = 2;
+}
+```
+
+| Field     | Type                 | Description             |
+| --------- | -------------------- | ----------------------- |
+| `code`    | int32                | gRPC status code (0-16) |
+| `message` | string               | Error message           |
+| `details` | repeated ErrorDetail | Rich error details      |
+
+**ErrorDetail types:**
+
+- `bad_request` - Uses `field_violations` for validation errors
+- `retry_info` - Uses `retry_delay_ms` for retry guidance
+- `debug_info` - Uses `stack_entries` and `debug_detail`
+- `quota_failure` - Uses `quota_violations` for quota errors
+
 ## RPCs
 
 ### Echo (Unary)
@@ -162,6 +328,178 @@ ERROR:
   Message: resource not found
 ```
 
+### EchoRequestMetadata (Unary)
+
+Returns all request metadata in response body. Useful for verifying auth tokens and custom headers.
+
+```bash
+grpcurl -plaintext \
+  -H "authorization: Bearer token123" \
+  -H "x-request-id: req-456" \
+  -d '{}' \
+  localhost:50051 echo.v1.Echo/EchoRequestMetadata
+```
+
+**Response:**
+
+```json
+{
+  "metadata": {
+    "authorization": { "values": ["Bearer token123"] },
+    "x-request-id": { "values": ["req-456"] },
+    "content-type": { "values": ["application/grpc"] }
+  }
+}
+```
+
+**Filter to specific keys:**
+
+```bash
+grpcurl -plaintext \
+  -H "authorization: Bearer token123" \
+  -H "x-request-id: req-456" \
+  -d '{"keys": ["authorization"]}' \
+  localhost:50051 echo.v1.Echo/EchoRequestMetadata
+```
+
+### EchoWithTrailers (Unary)
+
+Return response with specified trailing metadata. Useful for testing trailer handling.
+
+```bash
+grpcurl -plaintext -d '{
+  "message": "hello",
+  "trailers": {
+    "x-custom-trailer": "value1",
+    "x-timing": "100ms"
+  }
+}' localhost:50051 echo.v1.Echo/EchoWithTrailers
+```
+
+**Response:**
+
+```json
+{
+  "message": "hello",
+  "metadata": {
+    "content-type": "application/grpc"
+  }
+}
+```
+
+Trailers can be received using grpcurl's `-v` flag or programmatically via `grpc.Trailer()`.
+
+### EchoLargePayload (Unary)
+
+Returns a large payload of specified size. Useful for testing payload limits and chunking.
+
+```bash
+grpcurl -plaintext -d '{"size_bytes": 1024, "pattern": "ABC"}' \
+  localhost:50051 echo.v1.Echo/EchoLargePayload
+```
+
+**Response:**
+
+```json
+{
+  "payload": "QUJDQUJDQUJD...", // base64 encoded
+  "actualSize": 1024
+}
+```
+
+**Limits:** Maximum 10MB (10,485,760 bytes)
+
+### EchoDeadline (Unary)
+
+Echo the remaining deadline/timeout. Useful for verifying timeout propagation.
+
+```bash
+grpcurl -plaintext -max-time 10 -d '{"message": "test"}' \
+  localhost:50051 echo.v1.Echo/EchoDeadline
+```
+
+**Response:**
+
+```json
+{
+  "message": "test",
+  "deadlineRemainingMs": 9850,
+  "hasDeadline": true
+}
+```
+
+**Without deadline:**
+
+```json
+{
+  "message": "test",
+  "deadlineRemainingMs": -1,
+  "hasDeadline": false
+}
+```
+
+### EchoErrorWithDetails (Unary)
+
+Returns error with rich error details using `google.rpc.Status`.
+
+**BadRequest example:**
+
+```bash
+grpcurl -plaintext -d '{
+  "code": 3,
+  "message": "validation failed",
+  "details": [{
+    "type": "bad_request",
+    "field_violations": [
+      {"field": "email", "description": "invalid email format"},
+      {"field": "age", "description": "must be positive"}
+    ]
+  }]
+}' localhost:50051 echo.v1.Echo/EchoErrorWithDetails
+```
+
+**RetryInfo example:**
+
+```bash
+grpcurl -plaintext -d '{
+  "code": 14,
+  "message": "service temporarily unavailable",
+  "details": [{
+    "type": "retry_info",
+    "retry_delay_ms": 5000
+  }]
+}' localhost:50051 echo.v1.Echo/EchoErrorWithDetails
+```
+
+**DebugInfo example:**
+
+```bash
+grpcurl -plaintext -d '{
+  "code": 13,
+  "message": "internal error",
+  "details": [{
+    "type": "debug_info",
+    "stack_entries": ["main.go:42", "handler.go:15"],
+    "debug_detail": "null pointer exception"
+  }]
+}' localhost:50051 echo.v1.Echo/EchoErrorWithDetails
+```
+
+**QuotaFailure example:**
+
+```bash
+grpcurl -plaintext -d '{
+  "code": 8,
+  "message": "quota exceeded",
+  "details": [{
+    "type": "quota_failure",
+    "quota_violations": [
+      {"subject": "user:123", "description": "API calls per minute exceeded"}
+    ]
+  }]
+}' localhost:50051 echo.v1.Echo/EchoErrorWithDetails
+```
+
 ### ServerStream (Server Streaming)
 
 Server sends multiple responses over time.
@@ -196,7 +534,7 @@ echo '{"message": "hello"}
 
 ```json
 {
-  "message": "Received 3 messages: hello, world, !",
+  "message": "hello, world, !",
   "metadata": {...}
 }
 ```
@@ -218,6 +556,41 @@ echo '{"message": "one"}
 {"message": "one", "metadata": {...}}
 {"message": "two", "metadata": {...}}
 {"message": "three", "metadata": {...}}
+```
+
+## Health Checking
+
+Standard gRPC health checking protocol is supported.
+
+### Check (Unary)
+
+```bash
+grpcurl -plaintext -d '{"service": ""}' \
+  localhost:50051 grpc.health.v1.Health/Check
+```
+
+**Response:**
+
+```json
+{
+  "status": "SERVING"
+}
+```
+
+**Check specific service:**
+
+```bash
+grpcurl -plaintext -d '{"service": "echo.v1.Echo"}' \
+  localhost:50051 grpc.health.v1.Health/Check
+```
+
+### Watch (Server Streaming)
+
+Stream health status changes.
+
+```bash
+grpcurl -plaintext -d '{"service": ""}' \
+  localhost:50051 grpc.health.v1.Health/Watch
 ```
 
 ## Server Reflection

--- a/echo-grpc/go.mod
+++ b/echo-grpc/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/joho/godotenv v1.5.1
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10
 )
@@ -12,5 +13,4 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846 // indirect
 )

--- a/echo-grpc/main.go
+++ b/echo-grpc/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
 	pb "github.com/jsr-probitas/dockerfiles/echo-grpc/proto"
@@ -26,6 +27,10 @@ func main() {
 	// Register echo service
 	echoServer := server.NewEchoServer()
 	pb.RegisterEchoServer(s, echoServer)
+
+	// Register health service (grpc.health.v1)
+	healthServer := server.NewHealthServer()
+	healthpb.RegisterHealthServer(s, healthServer)
 
 	// Enable server reflection (v1 and v1alpha)
 	reflection.Register(s)

--- a/echo-grpc/proto/echo.pb.go
+++ b/echo-grpc/proto/echo.pb.go
@@ -290,6 +290,658 @@ func (x *ServerStreamRequest) GetIntervalMs() int32 {
 	return 0
 }
 
+// EchoRequestMetadata - Returns all request metadata in response body
+type EchoRequestMetadataRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Optional: filter to specific metadata keys (empty = return all)
+	Keys          []string `protobuf:"bytes,1,rep,name=keys,proto3" json:"keys,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoRequestMetadataRequest) Reset() {
+	*x = EchoRequestMetadataRequest{}
+	mi := &file_proto_echo_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoRequestMetadataRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoRequestMetadataRequest) ProtoMessage() {}
+
+func (x *EchoRequestMetadataRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoRequestMetadataRequest.ProtoReflect.Descriptor instead.
+func (*EchoRequestMetadataRequest) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *EchoRequestMetadataRequest) GetKeys() []string {
+	if x != nil {
+		return x.Keys
+	}
+	return nil
+}
+
+type EchoRequestMetadataResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// All request metadata as key-value pairs
+	Metadata      map[string]*MetadataValues `protobuf:"bytes,1,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoRequestMetadataResponse) Reset() {
+	*x = EchoRequestMetadataResponse{}
+	mi := &file_proto_echo_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoRequestMetadataResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoRequestMetadataResponse) ProtoMessage() {}
+
+func (x *EchoRequestMetadataResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoRequestMetadataResponse.ProtoReflect.Descriptor instead.
+func (*EchoRequestMetadataResponse) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *EchoRequestMetadataResponse) GetMetadata() map[string]*MetadataValues {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+// MetadataValues holds multiple values for a single metadata key
+type MetadataValues struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Values        []string               `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetadataValues) Reset() {
+	*x = MetadataValues{}
+	mi := &file_proto_echo_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetadataValues) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetadataValues) ProtoMessage() {}
+
+func (x *MetadataValues) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetadataValues.ProtoReflect.Descriptor instead.
+func (*MetadataValues) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *MetadataValues) GetValues() []string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+// EchoWithTrailers - Return response with trailing metadata
+type EchoWithTrailersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Message       string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	Trailers      map[string]string      `protobuf:"bytes,2,rep,name=trailers,proto3" json:"trailers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Trailers to send with response
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoWithTrailersRequest) Reset() {
+	*x = EchoWithTrailersRequest{}
+	mi := &file_proto_echo_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoWithTrailersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoWithTrailersRequest) ProtoMessage() {}
+
+func (x *EchoWithTrailersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoWithTrailersRequest.ProtoReflect.Descriptor instead.
+func (*EchoWithTrailersRequest) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *EchoWithTrailersRequest) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *EchoWithTrailersRequest) GetTrailers() map[string]string {
+	if x != nil {
+		return x.Trailers
+	}
+	return nil
+}
+
+// EchoLargePayload - Returns large payload of specified size
+type EchoLargePayloadRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SizeBytes     int32                  `protobuf:"varint,1,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"` // Size of payload to return (max 10MB)
+	Pattern       string                 `protobuf:"bytes,2,opt,name=pattern,proto3" json:"pattern,omitempty"`                       // Optional: pattern to repeat (default: 'X')
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoLargePayloadRequest) Reset() {
+	*x = EchoLargePayloadRequest{}
+	mi := &file_proto_echo_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoLargePayloadRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoLargePayloadRequest) ProtoMessage() {}
+
+func (x *EchoLargePayloadRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoLargePayloadRequest.ProtoReflect.Descriptor instead.
+func (*EchoLargePayloadRequest) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *EchoLargePayloadRequest) GetSizeBytes() int32 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *EchoLargePayloadRequest) GetPattern() string {
+	if x != nil {
+		return x.Pattern
+	}
+	return ""
+}
+
+type EchoLargePayloadResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Payload       []byte                 `protobuf:"bytes,1,opt,name=payload,proto3" json:"payload,omitempty"`
+	ActualSize    int32                  `protobuf:"varint,2,opt,name=actual_size,json=actualSize,proto3" json:"actual_size,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoLargePayloadResponse) Reset() {
+	*x = EchoLargePayloadResponse{}
+	mi := &file_proto_echo_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoLargePayloadResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoLargePayloadResponse) ProtoMessage() {}
+
+func (x *EchoLargePayloadResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoLargePayloadResponse.ProtoReflect.Descriptor instead.
+func (*EchoLargePayloadResponse) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *EchoLargePayloadResponse) GetPayload() []byte {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *EchoLargePayloadResponse) GetActualSize() int32 {
+	if x != nil {
+		return x.ActualSize
+	}
+	return 0
+}
+
+// EchoDeadline - Echo the remaining deadline/timeout
+type EchoDeadlineRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Message       string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoDeadlineRequest) Reset() {
+	*x = EchoDeadlineRequest{}
+	mi := &file_proto_echo_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoDeadlineRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoDeadlineRequest) ProtoMessage() {}
+
+func (x *EchoDeadlineRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoDeadlineRequest.ProtoReflect.Descriptor instead.
+func (*EchoDeadlineRequest) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *EchoDeadlineRequest) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+type EchoDeadlineResponse struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Message             string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	DeadlineRemainingMs int64                  `protobuf:"varint,2,opt,name=deadline_remaining_ms,json=deadlineRemainingMs,proto3" json:"deadline_remaining_ms,omitempty"` // -1 if no deadline set
+	HasDeadline         bool                   `protobuf:"varint,3,opt,name=has_deadline,json=hasDeadline,proto3" json:"has_deadline,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *EchoDeadlineResponse) Reset() {
+	*x = EchoDeadlineResponse{}
+	mi := &file_proto_echo_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoDeadlineResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoDeadlineResponse) ProtoMessage() {}
+
+func (x *EchoDeadlineResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoDeadlineResponse.ProtoReflect.Descriptor instead.
+func (*EchoDeadlineResponse) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *EchoDeadlineResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *EchoDeadlineResponse) GetDeadlineRemainingMs() int64 {
+	if x != nil {
+		return x.DeadlineRemainingMs
+	}
+	return 0
+}
+
+func (x *EchoDeadlineResponse) GetHasDeadline() bool {
+	if x != nil {
+		return x.HasDeadline
+	}
+	return false
+}
+
+// EchoErrorWithDetails - Return error with rich error details (google.rpc.Status)
+type EchoErrorWithDetailsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          int32                  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`      // gRPC status code (0-16)
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"` // Error message
+	Details       []*ErrorDetail         `protobuf:"bytes,3,rep,name=details,proto3" json:"details,omitempty"` // Rich error details
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EchoErrorWithDetailsRequest) Reset() {
+	*x = EchoErrorWithDetailsRequest{}
+	mi := &file_proto_echo_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EchoErrorWithDetailsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EchoErrorWithDetailsRequest) ProtoMessage() {}
+
+func (x *EchoErrorWithDetailsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EchoErrorWithDetailsRequest.ProtoReflect.Descriptor instead.
+func (*EchoErrorWithDetailsRequest) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *EchoErrorWithDetailsRequest) GetCode() int32 {
+	if x != nil {
+		return x.Code
+	}
+	return 0
+}
+
+func (x *EchoErrorWithDetailsRequest) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *EchoErrorWithDetailsRequest) GetDetails() []*ErrorDetail {
+	if x != nil {
+		return x.Details
+	}
+	return nil
+}
+
+type ErrorDetail struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Type  string                 `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"` // Detail type: "bad_request", "retry_info", "debug_info", "quota_failure"
+	// Fields for BadRequest
+	FieldViolations []*FieldViolation `protobuf:"bytes,2,rep,name=field_violations,json=fieldViolations,proto3" json:"field_violations,omitempty"`
+	// Fields for RetryInfo
+	RetryDelayMs int64 `protobuf:"varint,3,opt,name=retry_delay_ms,json=retryDelayMs,proto3" json:"retry_delay_ms,omitempty"`
+	// Fields for DebugInfo
+	StackEntries []string `protobuf:"bytes,4,rep,name=stack_entries,json=stackEntries,proto3" json:"stack_entries,omitempty"`
+	DebugDetail  string   `protobuf:"bytes,5,opt,name=debug_detail,json=debugDetail,proto3" json:"debug_detail,omitempty"`
+	// Fields for QuotaFailure
+	QuotaViolations []*QuotaViolation `protobuf:"bytes,6,rep,name=quota_violations,json=quotaViolations,proto3" json:"quota_violations,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ErrorDetail) Reset() {
+	*x = ErrorDetail{}
+	mi := &file_proto_echo_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ErrorDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ErrorDetail) ProtoMessage() {}
+
+func (x *ErrorDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ErrorDetail.ProtoReflect.Descriptor instead.
+func (*ErrorDetail) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *ErrorDetail) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *ErrorDetail) GetFieldViolations() []*FieldViolation {
+	if x != nil {
+		return x.FieldViolations
+	}
+	return nil
+}
+
+func (x *ErrorDetail) GetRetryDelayMs() int64 {
+	if x != nil {
+		return x.RetryDelayMs
+	}
+	return 0
+}
+
+func (x *ErrorDetail) GetStackEntries() []string {
+	if x != nil {
+		return x.StackEntries
+	}
+	return nil
+}
+
+func (x *ErrorDetail) GetDebugDetail() string {
+	if x != nil {
+		return x.DebugDetail
+	}
+	return ""
+}
+
+func (x *ErrorDetail) GetQuotaViolations() []*QuotaViolation {
+	if x != nil {
+		return x.QuotaViolations
+	}
+	return nil
+}
+
+type FieldViolation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Field         string                 `protobuf:"bytes,1,opt,name=field,proto3" json:"field,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FieldViolation) Reset() {
+	*x = FieldViolation{}
+	mi := &file_proto_echo_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FieldViolation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FieldViolation) ProtoMessage() {}
+
+func (x *FieldViolation) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FieldViolation.ProtoReflect.Descriptor instead.
+func (*FieldViolation) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *FieldViolation) GetField() string {
+	if x != nil {
+		return x.Field
+	}
+	return ""
+}
+
+func (x *FieldViolation) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+type QuotaViolation struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Subject       string                 `protobuf:"bytes,1,opt,name=subject,proto3" json:"subject,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QuotaViolation) Reset() {
+	*x = QuotaViolation{}
+	mi := &file_proto_echo_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QuotaViolation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QuotaViolation) ProtoMessage() {}
+
+func (x *QuotaViolation) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_echo_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QuotaViolation.ProtoReflect.Descriptor instead.
+func (*QuotaViolation) Descriptor() ([]byte, []int) {
+	return file_proto_echo_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *QuotaViolation) GetSubject() string {
+	if x != nil {
+		return x.Subject
+	}
+	return ""
+}
+
+func (x *QuotaViolation) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
 var File_proto_echo_proto protoreflect.FileDescriptor
 
 const file_proto_echo_proto_rawDesc = "" +
@@ -314,11 +966,62 @@ const file_proto_echo_proto_rawDesc = "" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x14\n" +
 	"\x05count\x18\x02 \x01(\x05R\x05count\x12\x1f\n" +
 	"\vinterval_ms\x18\x03 \x01(\x05R\n" +
-	"intervalMs2\x8f\x03\n" +
+	"intervalMs\"0\n" +
+	"\x1aEchoRequestMetadataRequest\x12\x12\n" +
+	"\x04keys\x18\x01 \x03(\tR\x04keys\"\xc3\x01\n" +
+	"\x1bEchoRequestMetadataResponse\x12N\n" +
+	"\bmetadata\x18\x01 \x03(\v22.echo.v1.EchoRequestMetadataResponse.MetadataEntryR\bmetadata\x1aT\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
+	"\x05value\x18\x02 \x01(\v2\x17.echo.v1.MetadataValuesR\x05value:\x028\x01\"(\n" +
+	"\x0eMetadataValues\x12\x16\n" +
+	"\x06values\x18\x01 \x03(\tR\x06values\"\xbc\x01\n" +
+	"\x17EchoWithTrailersRequest\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12J\n" +
+	"\btrailers\x18\x02 \x03(\v2..echo.v1.EchoWithTrailersRequest.TrailersEntryR\btrailers\x1a;\n" +
+	"\rTrailersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"R\n" +
+	"\x17EchoLargePayloadRequest\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x01 \x01(\x05R\tsizeBytes\x12\x18\n" +
+	"\apattern\x18\x02 \x01(\tR\apattern\"U\n" +
+	"\x18EchoLargePayloadResponse\x12\x18\n" +
+	"\apayload\x18\x01 \x01(\fR\apayload\x12\x1f\n" +
+	"\vactual_size\x18\x02 \x01(\x05R\n" +
+	"actualSize\"/\n" +
+	"\x13EchoDeadlineRequest\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\"\x87\x01\n" +
+	"\x14EchoDeadlineResponse\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x122\n" +
+	"\x15deadline_remaining_ms\x18\x02 \x01(\x03R\x13deadlineRemainingMs\x12!\n" +
+	"\fhas_deadline\x18\x03 \x01(\bR\vhasDeadline\"{\n" +
+	"\x1bEchoErrorWithDetailsRequest\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\x05R\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12.\n" +
+	"\adetails\x18\x03 \x03(\v2\x14.echo.v1.ErrorDetailR\adetails\"\x97\x02\n" +
+	"\vErrorDetail\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12B\n" +
+	"\x10field_violations\x18\x02 \x03(\v2\x17.echo.v1.FieldViolationR\x0ffieldViolations\x12$\n" +
+	"\x0eretry_delay_ms\x18\x03 \x01(\x03R\fretryDelayMs\x12#\n" +
+	"\rstack_entries\x18\x04 \x03(\tR\fstackEntries\x12!\n" +
+	"\fdebug_detail\x18\x05 \x01(\tR\vdebugDetail\x12B\n" +
+	"\x10quota_violations\x18\x06 \x03(\v2\x17.echo.v1.QuotaViolationR\x0fquotaViolations\"H\n" +
+	"\x0eFieldViolation\x12\x14\n" +
+	"\x05field\x18\x01 \x01(\tR\x05field\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\"L\n" +
+	"\x0eQuotaViolation\x12\x18\n" +
+	"\asubject\x18\x01 \x01(\tR\asubject\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription2\xb9\x06\n" +
 	"\x04Echo\x123\n" +
 	"\x04Echo\x12\x14.echo.v1.EchoRequest\x1a\x15.echo.v1.EchoResponse\x12E\n" +
 	"\rEchoWithDelay\x12\x1d.echo.v1.EchoWithDelayRequest\x1a\x15.echo.v1.EchoResponse\x12=\n" +
-	"\tEchoError\x12\x19.echo.v1.EchoErrorRequest\x1a\x15.echo.v1.EchoResponse\x12E\n" +
+	"\tEchoError\x12\x19.echo.v1.EchoErrorRequest\x1a\x15.echo.v1.EchoResponse\x12`\n" +
+	"\x13EchoRequestMetadata\x12#.echo.v1.EchoRequestMetadataRequest\x1a$.echo.v1.EchoRequestMetadataResponse\x12K\n" +
+	"\x10EchoWithTrailers\x12 .echo.v1.EchoWithTrailersRequest\x1a\x15.echo.v1.EchoResponse\x12W\n" +
+	"\x10EchoLargePayload\x12 .echo.v1.EchoLargePayloadRequest\x1a!.echo.v1.EchoLargePayloadResponse\x12K\n" +
+	"\fEchoDeadline\x12\x1c.echo.v1.EchoDeadlineRequest\x1a\x1d.echo.v1.EchoDeadlineResponse\x12S\n" +
+	"\x14EchoErrorWithDetails\x12$.echo.v1.EchoErrorWithDetailsRequest\x1a\x15.echo.v1.EchoResponse\x12E\n" +
 	"\fServerStream\x12\x1c.echo.v1.ServerStreamRequest\x1a\x15.echo.v1.EchoResponse0\x01\x12=\n" +
 	"\fClientStream\x12\x14.echo.v1.EchoRequest\x1a\x15.echo.v1.EchoResponse(\x01\x12F\n" +
 	"\x13BidirectionalStream\x12\x14.echo.v1.EchoRequest\x1a\x15.echo.v1.EchoResponse(\x010\x01B5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
@@ -335,34 +1038,64 @@ func file_proto_echo_proto_rawDescGZIP() []byte {
 	return file_proto_echo_proto_rawDescData
 }
 
-var file_proto_echo_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_proto_echo_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_proto_echo_proto_goTypes = []any{
-	(*EchoRequest)(nil),          // 0: echo.v1.EchoRequest
-	(*EchoResponse)(nil),         // 1: echo.v1.EchoResponse
-	(*EchoWithDelayRequest)(nil), // 2: echo.v1.EchoWithDelayRequest
-	(*EchoErrorRequest)(nil),     // 3: echo.v1.EchoErrorRequest
-	(*ServerStreamRequest)(nil),  // 4: echo.v1.ServerStreamRequest
-	nil,                          // 5: echo.v1.EchoResponse.MetadataEntry
+	(*EchoRequest)(nil),                 // 0: echo.v1.EchoRequest
+	(*EchoResponse)(nil),                // 1: echo.v1.EchoResponse
+	(*EchoWithDelayRequest)(nil),        // 2: echo.v1.EchoWithDelayRequest
+	(*EchoErrorRequest)(nil),            // 3: echo.v1.EchoErrorRequest
+	(*ServerStreamRequest)(nil),         // 4: echo.v1.ServerStreamRequest
+	(*EchoRequestMetadataRequest)(nil),  // 5: echo.v1.EchoRequestMetadataRequest
+	(*EchoRequestMetadataResponse)(nil), // 6: echo.v1.EchoRequestMetadataResponse
+	(*MetadataValues)(nil),              // 7: echo.v1.MetadataValues
+	(*EchoWithTrailersRequest)(nil),     // 8: echo.v1.EchoWithTrailersRequest
+	(*EchoLargePayloadRequest)(nil),     // 9: echo.v1.EchoLargePayloadRequest
+	(*EchoLargePayloadResponse)(nil),    // 10: echo.v1.EchoLargePayloadResponse
+	(*EchoDeadlineRequest)(nil),         // 11: echo.v1.EchoDeadlineRequest
+	(*EchoDeadlineResponse)(nil),        // 12: echo.v1.EchoDeadlineResponse
+	(*EchoErrorWithDetailsRequest)(nil), // 13: echo.v1.EchoErrorWithDetailsRequest
+	(*ErrorDetail)(nil),                 // 14: echo.v1.ErrorDetail
+	(*FieldViolation)(nil),              // 15: echo.v1.FieldViolation
+	(*QuotaViolation)(nil),              // 16: echo.v1.QuotaViolation
+	nil,                                 // 17: echo.v1.EchoResponse.MetadataEntry
+	nil,                                 // 18: echo.v1.EchoRequestMetadataResponse.MetadataEntry
+	nil,                                 // 19: echo.v1.EchoWithTrailersRequest.TrailersEntry
 }
 var file_proto_echo_proto_depIdxs = []int32{
-	5, // 0: echo.v1.EchoResponse.metadata:type_name -> echo.v1.EchoResponse.MetadataEntry
-	0, // 1: echo.v1.Echo.Echo:input_type -> echo.v1.EchoRequest
-	2, // 2: echo.v1.Echo.EchoWithDelay:input_type -> echo.v1.EchoWithDelayRequest
-	3, // 3: echo.v1.Echo.EchoError:input_type -> echo.v1.EchoErrorRequest
-	4, // 4: echo.v1.Echo.ServerStream:input_type -> echo.v1.ServerStreamRequest
-	0, // 5: echo.v1.Echo.ClientStream:input_type -> echo.v1.EchoRequest
-	0, // 6: echo.v1.Echo.BidirectionalStream:input_type -> echo.v1.EchoRequest
-	1, // 7: echo.v1.Echo.Echo:output_type -> echo.v1.EchoResponse
-	1, // 8: echo.v1.Echo.EchoWithDelay:output_type -> echo.v1.EchoResponse
-	1, // 9: echo.v1.Echo.EchoError:output_type -> echo.v1.EchoResponse
-	1, // 10: echo.v1.Echo.ServerStream:output_type -> echo.v1.EchoResponse
-	1, // 11: echo.v1.Echo.ClientStream:output_type -> echo.v1.EchoResponse
-	1, // 12: echo.v1.Echo.BidirectionalStream:output_type -> echo.v1.EchoResponse
-	7, // [7:13] is the sub-list for method output_type
-	1, // [1:7] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	17, // 0: echo.v1.EchoResponse.metadata:type_name -> echo.v1.EchoResponse.MetadataEntry
+	18, // 1: echo.v1.EchoRequestMetadataResponse.metadata:type_name -> echo.v1.EchoRequestMetadataResponse.MetadataEntry
+	19, // 2: echo.v1.EchoWithTrailersRequest.trailers:type_name -> echo.v1.EchoWithTrailersRequest.TrailersEntry
+	14, // 3: echo.v1.EchoErrorWithDetailsRequest.details:type_name -> echo.v1.ErrorDetail
+	15, // 4: echo.v1.ErrorDetail.field_violations:type_name -> echo.v1.FieldViolation
+	16, // 5: echo.v1.ErrorDetail.quota_violations:type_name -> echo.v1.QuotaViolation
+	7,  // 6: echo.v1.EchoRequestMetadataResponse.MetadataEntry.value:type_name -> echo.v1.MetadataValues
+	0,  // 7: echo.v1.Echo.Echo:input_type -> echo.v1.EchoRequest
+	2,  // 8: echo.v1.Echo.EchoWithDelay:input_type -> echo.v1.EchoWithDelayRequest
+	3,  // 9: echo.v1.Echo.EchoError:input_type -> echo.v1.EchoErrorRequest
+	5,  // 10: echo.v1.Echo.EchoRequestMetadata:input_type -> echo.v1.EchoRequestMetadataRequest
+	8,  // 11: echo.v1.Echo.EchoWithTrailers:input_type -> echo.v1.EchoWithTrailersRequest
+	9,  // 12: echo.v1.Echo.EchoLargePayload:input_type -> echo.v1.EchoLargePayloadRequest
+	11, // 13: echo.v1.Echo.EchoDeadline:input_type -> echo.v1.EchoDeadlineRequest
+	13, // 14: echo.v1.Echo.EchoErrorWithDetails:input_type -> echo.v1.EchoErrorWithDetailsRequest
+	4,  // 15: echo.v1.Echo.ServerStream:input_type -> echo.v1.ServerStreamRequest
+	0,  // 16: echo.v1.Echo.ClientStream:input_type -> echo.v1.EchoRequest
+	0,  // 17: echo.v1.Echo.BidirectionalStream:input_type -> echo.v1.EchoRequest
+	1,  // 18: echo.v1.Echo.Echo:output_type -> echo.v1.EchoResponse
+	1,  // 19: echo.v1.Echo.EchoWithDelay:output_type -> echo.v1.EchoResponse
+	1,  // 20: echo.v1.Echo.EchoError:output_type -> echo.v1.EchoResponse
+	6,  // 21: echo.v1.Echo.EchoRequestMetadata:output_type -> echo.v1.EchoRequestMetadataResponse
+	1,  // 22: echo.v1.Echo.EchoWithTrailers:output_type -> echo.v1.EchoResponse
+	10, // 23: echo.v1.Echo.EchoLargePayload:output_type -> echo.v1.EchoLargePayloadResponse
+	12, // 24: echo.v1.Echo.EchoDeadline:output_type -> echo.v1.EchoDeadlineResponse
+	1,  // 25: echo.v1.Echo.EchoErrorWithDetails:output_type -> echo.v1.EchoResponse
+	1,  // 26: echo.v1.Echo.ServerStream:output_type -> echo.v1.EchoResponse
+	1,  // 27: echo.v1.Echo.ClientStream:output_type -> echo.v1.EchoResponse
+	1,  // 28: echo.v1.Echo.BidirectionalStream:output_type -> echo.v1.EchoResponse
+	18, // [18:29] is the sub-list for method output_type
+	7,  // [7:18] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_proto_echo_proto_init() }
@@ -376,7 +1109,7 @@ func file_proto_echo_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_echo_proto_rawDesc), len(file_proto_echo_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/echo-grpc/proto/echo.proto
+++ b/echo-grpc/proto/echo.proto
@@ -11,6 +11,19 @@ service Echo {
   rpc EchoWithDelay (EchoWithDelayRequest) returns (EchoResponse);
   rpc EchoError (EchoErrorRequest) returns (EchoResponse);
 
+  // Metadata/Headers RPCs
+  rpc EchoRequestMetadata (EchoRequestMetadataRequest) returns (EchoRequestMetadataResponse);
+  rpc EchoWithTrailers (EchoWithTrailersRequest) returns (EchoResponse);
+
+  // Payload Testing RPCs
+  rpc EchoLargePayload (EchoLargePayloadRequest) returns (EchoLargePayloadResponse);
+
+  // Deadline/Timeout RPCs
+  rpc EchoDeadline (EchoDeadlineRequest) returns (EchoDeadlineResponse);
+
+  // Error Scenarios RPCs
+  rpc EchoErrorWithDetails (EchoErrorWithDetailsRequest) returns (EchoResponse);
+
   // Streaming RPCs
   rpc ServerStream (ServerStreamRequest) returns (stream EchoResponse);
   rpc ClientStream (stream EchoRequest) returns (EchoResponse);
@@ -41,4 +54,78 @@ message ServerStreamRequest {
   string message = 1;
   int32 count = 2;       // Number of responses to stream
   int32 interval_ms = 3; // Interval between responses
+}
+
+// EchoRequestMetadata - Returns all request metadata in response body
+message EchoRequestMetadataRequest {
+  // Optional: filter to specific metadata keys (empty = return all)
+  repeated string keys = 1;
+}
+
+message EchoRequestMetadataResponse {
+  // All request metadata as key-value pairs
+  map<string, MetadataValues> metadata = 1;
+}
+
+// MetadataValues holds multiple values for a single metadata key
+message MetadataValues {
+  repeated string values = 1;
+}
+
+// EchoWithTrailers - Return response with trailing metadata
+message EchoWithTrailersRequest {
+  string message = 1;
+  map<string, string> trailers = 2;  // Trailers to send with response
+}
+
+// EchoLargePayload - Returns large payload of specified size
+message EchoLargePayloadRequest {
+  int32 size_bytes = 1;  // Size of payload to return (max 10MB)
+  string pattern = 2;    // Optional: pattern to repeat (default: 'X')
+}
+
+message EchoLargePayloadResponse {
+  bytes payload = 1;
+  int32 actual_size = 2;
+}
+
+// EchoDeadline - Echo the remaining deadline/timeout
+message EchoDeadlineRequest {
+  string message = 1;
+}
+
+message EchoDeadlineResponse {
+  string message = 1;
+  int64 deadline_remaining_ms = 2;  // -1 if no deadline set
+  bool has_deadline = 3;
+}
+
+// EchoErrorWithDetails - Return error with rich error details (google.rpc.Status)
+message EchoErrorWithDetailsRequest {
+  int32 code = 1;              // gRPC status code (0-16)
+  string message = 2;          // Error message
+  repeated ErrorDetail details = 3;  // Rich error details
+}
+
+message ErrorDetail {
+  string type = 1;  // Detail type: "bad_request", "retry_info", "debug_info", "quota_failure"
+  // Fields for BadRequest
+  repeated FieldViolation field_violations = 2;
+  // Fields for RetryInfo
+  int64 retry_delay_ms = 3;
+  // Fields for DebugInfo
+  repeated string stack_entries = 4;
+  string debug_detail = 5;
+  // Fields for QuotaFailure
+  repeated QuotaViolation quota_violations = 6;
+}
+
+message FieldViolation {
+  string field = 1;
+  string description = 2;
+}
+
+message QuotaViolation {
+  string subject = 1;
+  string description = 2;
 }

--- a/echo-grpc/proto/echo_grpc.pb.go
+++ b/echo-grpc/proto/echo_grpc.pb.go
@@ -20,12 +20,17 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Echo_Echo_FullMethodName                = "/echo.v1.Echo/Echo"
-	Echo_EchoWithDelay_FullMethodName       = "/echo.v1.Echo/EchoWithDelay"
-	Echo_EchoError_FullMethodName           = "/echo.v1.Echo/EchoError"
-	Echo_ServerStream_FullMethodName        = "/echo.v1.Echo/ServerStream"
-	Echo_ClientStream_FullMethodName        = "/echo.v1.Echo/ClientStream"
-	Echo_BidirectionalStream_FullMethodName = "/echo.v1.Echo/BidirectionalStream"
+	Echo_Echo_FullMethodName                 = "/echo.v1.Echo/Echo"
+	Echo_EchoWithDelay_FullMethodName        = "/echo.v1.Echo/EchoWithDelay"
+	Echo_EchoError_FullMethodName            = "/echo.v1.Echo/EchoError"
+	Echo_EchoRequestMetadata_FullMethodName  = "/echo.v1.Echo/EchoRequestMetadata"
+	Echo_EchoWithTrailers_FullMethodName     = "/echo.v1.Echo/EchoWithTrailers"
+	Echo_EchoLargePayload_FullMethodName     = "/echo.v1.Echo/EchoLargePayload"
+	Echo_EchoDeadline_FullMethodName         = "/echo.v1.Echo/EchoDeadline"
+	Echo_EchoErrorWithDetails_FullMethodName = "/echo.v1.Echo/EchoErrorWithDetails"
+	Echo_ServerStream_FullMethodName         = "/echo.v1.Echo/ServerStream"
+	Echo_ClientStream_FullMethodName         = "/echo.v1.Echo/ClientStream"
+	Echo_BidirectionalStream_FullMethodName  = "/echo.v1.Echo/BidirectionalStream"
 )
 
 // EchoClient is the client API for Echo service.
@@ -38,6 +43,15 @@ type EchoClient interface {
 	Echo(ctx context.Context, in *EchoRequest, opts ...grpc.CallOption) (*EchoResponse, error)
 	EchoWithDelay(ctx context.Context, in *EchoWithDelayRequest, opts ...grpc.CallOption) (*EchoResponse, error)
 	EchoError(ctx context.Context, in *EchoErrorRequest, opts ...grpc.CallOption) (*EchoResponse, error)
+	// Metadata/Headers RPCs
+	EchoRequestMetadata(ctx context.Context, in *EchoRequestMetadataRequest, opts ...grpc.CallOption) (*EchoRequestMetadataResponse, error)
+	EchoWithTrailers(ctx context.Context, in *EchoWithTrailersRequest, opts ...grpc.CallOption) (*EchoResponse, error)
+	// Payload Testing RPCs
+	EchoLargePayload(ctx context.Context, in *EchoLargePayloadRequest, opts ...grpc.CallOption) (*EchoLargePayloadResponse, error)
+	// Deadline/Timeout RPCs
+	EchoDeadline(ctx context.Context, in *EchoDeadlineRequest, opts ...grpc.CallOption) (*EchoDeadlineResponse, error)
+	// Error Scenarios RPCs
+	EchoErrorWithDetails(ctx context.Context, in *EchoErrorWithDetailsRequest, opts ...grpc.CallOption) (*EchoResponse, error)
 	// Streaming RPCs
 	ServerStream(ctx context.Context, in *ServerStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[EchoResponse], error)
 	ClientStream(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[EchoRequest, EchoResponse], error)
@@ -76,6 +90,56 @@ func (c *echoClient) EchoError(ctx context.Context, in *EchoErrorRequest, opts .
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(EchoResponse)
 	err := c.cc.Invoke(ctx, Echo_EchoError_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *echoClient) EchoRequestMetadata(ctx context.Context, in *EchoRequestMetadataRequest, opts ...grpc.CallOption) (*EchoRequestMetadataResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EchoRequestMetadataResponse)
+	err := c.cc.Invoke(ctx, Echo_EchoRequestMetadata_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *echoClient) EchoWithTrailers(ctx context.Context, in *EchoWithTrailersRequest, opts ...grpc.CallOption) (*EchoResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EchoResponse)
+	err := c.cc.Invoke(ctx, Echo_EchoWithTrailers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *echoClient) EchoLargePayload(ctx context.Context, in *EchoLargePayloadRequest, opts ...grpc.CallOption) (*EchoLargePayloadResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EchoLargePayloadResponse)
+	err := c.cc.Invoke(ctx, Echo_EchoLargePayload_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *echoClient) EchoDeadline(ctx context.Context, in *EchoDeadlineRequest, opts ...grpc.CallOption) (*EchoDeadlineResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EchoDeadlineResponse)
+	err := c.cc.Invoke(ctx, Echo_EchoDeadline_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *echoClient) EchoErrorWithDetails(ctx context.Context, in *EchoErrorWithDetailsRequest, opts ...grpc.CallOption) (*EchoResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EchoResponse)
+	err := c.cc.Invoke(ctx, Echo_EchoErrorWithDetails_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +201,15 @@ type EchoServer interface {
 	Echo(context.Context, *EchoRequest) (*EchoResponse, error)
 	EchoWithDelay(context.Context, *EchoWithDelayRequest) (*EchoResponse, error)
 	EchoError(context.Context, *EchoErrorRequest) (*EchoResponse, error)
+	// Metadata/Headers RPCs
+	EchoRequestMetadata(context.Context, *EchoRequestMetadataRequest) (*EchoRequestMetadataResponse, error)
+	EchoWithTrailers(context.Context, *EchoWithTrailersRequest) (*EchoResponse, error)
+	// Payload Testing RPCs
+	EchoLargePayload(context.Context, *EchoLargePayloadRequest) (*EchoLargePayloadResponse, error)
+	// Deadline/Timeout RPCs
+	EchoDeadline(context.Context, *EchoDeadlineRequest) (*EchoDeadlineResponse, error)
+	// Error Scenarios RPCs
+	EchoErrorWithDetails(context.Context, *EchoErrorWithDetailsRequest) (*EchoResponse, error)
 	// Streaming RPCs
 	ServerStream(*ServerStreamRequest, grpc.ServerStreamingServer[EchoResponse]) error
 	ClientStream(grpc.ClientStreamingServer[EchoRequest, EchoResponse]) error
@@ -159,6 +232,21 @@ func (UnimplementedEchoServer) EchoWithDelay(context.Context, *EchoWithDelayRequ
 }
 func (UnimplementedEchoServer) EchoError(context.Context, *EchoErrorRequest) (*EchoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method EchoError not implemented")
+}
+func (UnimplementedEchoServer) EchoRequestMetadata(context.Context, *EchoRequestMetadataRequest) (*EchoRequestMetadataResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EchoRequestMetadata not implemented")
+}
+func (UnimplementedEchoServer) EchoWithTrailers(context.Context, *EchoWithTrailersRequest) (*EchoResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EchoWithTrailers not implemented")
+}
+func (UnimplementedEchoServer) EchoLargePayload(context.Context, *EchoLargePayloadRequest) (*EchoLargePayloadResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EchoLargePayload not implemented")
+}
+func (UnimplementedEchoServer) EchoDeadline(context.Context, *EchoDeadlineRequest) (*EchoDeadlineResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EchoDeadline not implemented")
+}
+func (UnimplementedEchoServer) EchoErrorWithDetails(context.Context, *EchoErrorWithDetailsRequest) (*EchoResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method EchoErrorWithDetails not implemented")
 }
 func (UnimplementedEchoServer) ServerStream(*ServerStreamRequest, grpc.ServerStreamingServer[EchoResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method ServerStream not implemented")
@@ -244,6 +332,96 @@ func _Echo_EchoError_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Echo_EchoRequestMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EchoRequestMetadataRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EchoServer).EchoRequestMetadata(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Echo_EchoRequestMetadata_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServer).EchoRequestMetadata(ctx, req.(*EchoRequestMetadataRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Echo_EchoWithTrailers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EchoWithTrailersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EchoServer).EchoWithTrailers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Echo_EchoWithTrailers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServer).EchoWithTrailers(ctx, req.(*EchoWithTrailersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Echo_EchoLargePayload_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EchoLargePayloadRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EchoServer).EchoLargePayload(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Echo_EchoLargePayload_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServer).EchoLargePayload(ctx, req.(*EchoLargePayloadRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Echo_EchoDeadline_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EchoDeadlineRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EchoServer).EchoDeadline(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Echo_EchoDeadline_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServer).EchoDeadline(ctx, req.(*EchoDeadlineRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Echo_EchoErrorWithDetails_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EchoErrorWithDetailsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EchoServer).EchoErrorWithDetails(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Echo_EchoErrorWithDetails_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServer).EchoErrorWithDetails(ctx, req.(*EchoErrorWithDetailsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Echo_ServerStream_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(ServerStreamRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -287,6 +465,26 @@ var Echo_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "EchoError",
 			Handler:    _Echo_EchoError_Handler,
+		},
+		{
+			MethodName: "EchoRequestMetadata",
+			Handler:    _Echo_EchoRequestMetadata_Handler,
+		},
+		{
+			MethodName: "EchoWithTrailers",
+			Handler:    _Echo_EchoWithTrailers_Handler,
+		},
+		{
+			MethodName: "EchoLargePayload",
+			Handler:    _Echo_EchoLargePayload_Handler,
+		},
+		{
+			MethodName: "EchoDeadline",
+			Handler:    _Echo_EchoDeadline_Handler,
+		},
+		{
+			MethodName: "EchoErrorWithDetails",
+			Handler:    _Echo_EchoErrorWithDetails_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/echo-grpc/server/echo.go
+++ b/echo-grpc/server/echo.go
@@ -1,18 +1,26 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"strings"
 	"time"
 
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	pb "github.com/jsr-probitas/dockerfiles/echo-grpc/proto"
+)
+
+const (
+	// MaxPayloadSize is the maximum allowed payload size (10MB)
+	MaxPayloadSize = 10 * 1024 * 1024
 )
 
 type EchoServer struct {
@@ -79,6 +87,158 @@ func (s *EchoServer) EchoError(_ context.Context, req *pb.EchoErrorRequest) (*pb
 	}
 
 	return nil, status.Error(code, details)
+}
+
+func (s *EchoServer) EchoRequestMetadata(ctx context.Context, req *pb.EchoRequestMetadataRequest) (*pb.EchoRequestMetadataResponse, error) {
+	resp := &pb.EchoRequestMetadataResponse{
+		Metadata: make(map[string]*pb.MetadataValues),
+	}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return resp, nil
+	}
+
+	// If specific keys requested, filter to those
+	if len(req.Keys) > 0 {
+		for _, key := range req.Keys {
+			if values, exists := md[key]; exists {
+				resp.Metadata[key] = &pb.MetadataValues{Values: values}
+			}
+		}
+	} else {
+		// Return all metadata
+		for k, v := range md {
+			resp.Metadata[k] = &pb.MetadataValues{Values: v}
+		}
+	}
+
+	return resp, nil
+}
+
+func (s *EchoServer) EchoWithTrailers(ctx context.Context, req *pb.EchoWithTrailersRequest) (*pb.EchoResponse, error) {
+	resp := &pb.EchoResponse{
+		Message:  req.Message,
+		Metadata: make(map[string]string),
+	}
+
+	// Echo back request metadata in response body
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		for k, v := range md {
+			if len(v) > 0 {
+				resp.Metadata[k] = v[0]
+			}
+		}
+	}
+
+	// Set specified trailers
+	if len(req.Trailers) > 0 {
+		trailerMD := metadata.New(nil)
+		for k, v := range req.Trailers {
+			trailerMD.Set(k, v)
+		}
+		_ = grpc.SetTrailer(ctx, trailerMD)
+	}
+
+	return resp, nil
+}
+
+func (s *EchoServer) EchoLargePayload(_ context.Context, req *pb.EchoLargePayloadRequest) (*pb.EchoLargePayloadResponse, error) {
+	size := int(req.SizeBytes)
+	if size <= 0 {
+		size = 1
+	}
+	if size > MaxPayloadSize {
+		return nil, status.Errorf(codes.InvalidArgument, "requested size %d exceeds maximum %d bytes", size, MaxPayloadSize)
+	}
+
+	pattern := req.Pattern
+	if pattern == "" {
+		pattern = "X"
+	}
+
+	// Generate payload by repeating pattern
+	patternBytes := []byte(pattern)
+	payload := bytes.Repeat(patternBytes, (size/len(patternBytes))+1)
+	payload = payload[:size]
+
+	return &pb.EchoLargePayloadResponse{
+		Payload:    payload,
+		ActualSize: int32(len(payload)),
+	}, nil
+}
+
+func (s *EchoServer) EchoDeadline(ctx context.Context, req *pb.EchoDeadlineRequest) (*pb.EchoDeadlineResponse, error) {
+	resp := &pb.EchoDeadlineResponse{
+		Message:     req.Message,
+		HasDeadline: false,
+	}
+
+	deadline, ok := ctx.Deadline()
+	if ok {
+		resp.HasDeadline = true
+		remaining := time.Until(deadline)
+		resp.DeadlineRemainingMs = remaining.Milliseconds()
+	} else {
+		resp.DeadlineRemainingMs = -1
+	}
+
+	return resp, nil
+}
+
+func (s *EchoServer) EchoErrorWithDetails(_ context.Context, req *pb.EchoErrorWithDetailsRequest) (*pb.EchoResponse, error) {
+	code := codes.Code(req.Code)
+	if code > 16 {
+		code = codes.Unknown
+	}
+
+	message := req.Message
+	if message == "" {
+		message = fmt.Sprintf("error with code %d", req.Code)
+	}
+
+	st := status.New(code, message)
+
+	// Add rich error details
+	for _, detail := range req.Details {
+		var err error
+		switch detail.Type {
+		case "bad_request":
+			br := &errdetails.BadRequest{}
+			for _, fv := range detail.FieldViolations {
+				br.FieldViolations = append(br.FieldViolations, &errdetails.BadRequest_FieldViolation{
+					Field:       fv.Field,
+					Description: fv.Description,
+				})
+			}
+			st, err = st.WithDetails(br)
+		case "retry_info":
+			ri := &errdetails.RetryInfo{
+				RetryDelay: durationpb.New(time.Duration(detail.RetryDelayMs) * time.Millisecond),
+			}
+			st, err = st.WithDetails(ri)
+		case "debug_info":
+			di := &errdetails.DebugInfo{
+				StackEntries: detail.StackEntries,
+				Detail:       detail.DebugDetail,
+			}
+			st, err = st.WithDetails(di)
+		case "quota_failure":
+			qf := &errdetails.QuotaFailure{}
+			for _, qv := range detail.QuotaViolations {
+				qf.Violations = append(qf.Violations, &errdetails.QuotaFailure_Violation{
+					Subject:     qv.Subject,
+					Description: qv.Description,
+				})
+			}
+			st, err = st.WithDetails(qf)
+		}
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to attach error details: %v", err)
+		}
+	}
+
+	return nil, st.Err()
 }
 
 func (s *EchoServer) ServerStream(req *pb.ServerStreamRequest, stream grpc.ServerStreamingServer[pb.EchoResponse]) error {

--- a/echo-grpc/server/health.go
+++ b/echo-grpc/server/health.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"sync"
+
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// HealthServer wraps the standard gRPC health server with service management.
+type HealthServer struct {
+	*health.Server
+	mu       sync.RWMutex
+	services map[string]healthpb.HealthCheckResponse_ServingStatus
+}
+
+// NewHealthServer creates a new health server with default services.
+func NewHealthServer() *HealthServer {
+	h := &HealthServer{
+		Server:   health.NewServer(),
+		services: make(map[string]healthpb.HealthCheckResponse_ServingStatus),
+	}
+
+	// Set overall server status (empty service name = overall status)
+	h.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+
+	// Set Echo service status
+	h.SetServingStatus("echo.v1.Echo", healthpb.HealthCheckResponse_SERVING)
+
+	return h
+}
+
+// SetServingStatus updates the serving status for a service.
+func (h *HealthServer) SetServingStatus(service string, status healthpb.HealthCheckResponse_ServingStatus) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.services[service] = status
+	h.Server.SetServingStatus(service, status)
+}
+
+// GetServingStatus returns the current serving status for a service.
+func (h *HealthServer) GetServingStatus(service string) healthpb.HealthCheckResponse_ServingStatus {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if status, ok := h.services[service]; ok {
+		return status
+	}
+	return healthpb.HealthCheckResponse_SERVICE_UNKNOWN
+}
+
+// Shutdown sets all services to NOT_SERVING status.
+func (h *HealthServer) Shutdown() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for service := range h.services {
+		h.services[service] = healthpb.HealthCheckResponse_NOT_SERVING
+		h.Server.SetServingStatus(service, healthpb.HealthCheckResponse_NOT_SERVING)
+	}
+}

--- a/echo-grpc/server/health_test.go
+++ b/echo-grpc/server/health_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"testing"
+
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestNewHealthServer_SetsInitialServingStatus(t *testing.T) {
+	h := NewHealthServer()
+
+	// Overall server status should be SERVING
+	if status := h.GetServingStatus(""); status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("expected overall status SERVING, got %v", status)
+	}
+
+	// Echo service status should be SERVING
+	if status := h.GetServingStatus("echo.v1.Echo"); status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("expected echo.v1.Echo status SERVING, got %v", status)
+	}
+}
+
+func TestHealthServer_SetServingStatus(t *testing.T) {
+	h := NewHealthServer()
+
+	h.SetServingStatus("test.service", healthpb.HealthCheckResponse_SERVING)
+	if status := h.GetServingStatus("test.service"); status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("expected SERVING, got %v", status)
+	}
+
+	h.SetServingStatus("test.service", healthpb.HealthCheckResponse_NOT_SERVING)
+	if status := h.GetServingStatus("test.service"); status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("expected NOT_SERVING, got %v", status)
+	}
+}
+
+func TestHealthServer_GetServingStatus_UnknownService(t *testing.T) {
+	h := NewHealthServer()
+
+	status := h.GetServingStatus("unknown.service")
+	if status != healthpb.HealthCheckResponse_SERVICE_UNKNOWN {
+		t.Errorf("expected SERVICE_UNKNOWN for unregistered service, got %v", status)
+	}
+}
+
+func TestHealthServer_Shutdown(t *testing.T) {
+	h := NewHealthServer()
+
+	// Add additional service
+	h.SetServingStatus("test.service", healthpb.HealthCheckResponse_SERVING)
+
+	// Shutdown
+	h.Shutdown()
+
+	// All services should be NOT_SERVING after shutdown
+	if status := h.GetServingStatus(""); status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("expected overall status NOT_SERVING after shutdown, got %v", status)
+	}
+	if status := h.GetServingStatus("echo.v1.Echo"); status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("expected echo.v1.Echo status NOT_SERVING after shutdown, got %v", status)
+	}
+	if status := h.GetServingStatus("test.service"); status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("expected test.service status NOT_SERVING after shutdown, got %v", status)
+	}
+}


### PR DESCRIPTION
## Summary

Implement additional RPCs for comprehensive gRPC client testing as specified in Issue #5:

- **HealthCheck**: Standard gRPC health checking protocol (`grpc.health.v1.Health/Check` and `Watch`)
- **EchoRequestMetadata**: Return all request metadata with optional key filtering
- **EchoWithTrailers**: Return response with custom trailing metadata
- **EchoLargePayload**: Return large payload up to 10MB with custom pattern
- **EchoDeadline**: Echo remaining deadline/timeout information
- **EchoErrorWithDetails**: Return rich error details (BadRequest, RetryInfo, DebugInfo, QuotaFailure)

## Changes

| File | Description |
|------|-------------|
| `proto/echo.proto` | Added new RPC definitions and messages |
| `server/echo.go` | Implemented new RPC handlers |
| `server/health.go` | New health server wrapper |
| `server/echo_test.go` | Added 24 test cases for all RPCs |
| `server/health_test.go` | Added health server unit tests |
| `docs/api.md` | Complete API documentation with examples |
| `main.go` | Registered health service |

## Test plan

- [x] `just lint` - 0 issues
- [x] `just test` - 24 test cases pass
- [x] `just build` - builds successfully

Closes #5