### PR TITLE
Add version-specific reflection API toggle for echo-grpc

### DIFF
--- a/echo-grpc/README.md
+++ b/echo-grpc/README.md
@@ -22,6 +22,8 @@ docker run -p 50051:50051 ghcr.io/jsr-probitas/echo-grpc:latest
 - `HOST` (default `0.0.0.0`): Bind address
 - `PORT` (default `50051`): Listen port
 - `REFLECTION_INCLUDE_DEPENDENCIES` (default `false`): If `true`, server reflection returns transitive proto dependencies (standard gRPC behavior). Default `false` returns only the containing file to reproduce missing-import scenarios.
+- `DISABLE_REFLECTION_V1` (default `false`): Disable gRPC reflection v1 API
+- `DISABLE_REFLECTION_V1ALPHA` (default `false`): Disable gRPC reflection v1alpha API
 
 ```bash
 # Custom port
@@ -29,6 +31,12 @@ docker run -p 9000:9000 -e PORT=9000 ghcr.io/jsr-probitas/echo-grpc:latest
 
 # Using .env file
 docker run -p 50051:50051 -v $(pwd)/.env:/app/.env ghcr.io/jsr-probitas/echo-grpc:latest
+
+# Disable v1alpha reflection (v1 only)
+docker run -p 50051:50051 -e DISABLE_REFLECTION_V1ALPHA=true ghcr.io/jsr-probitas/echo-grpc:latest
+
+# Disable v1 reflection (v1alpha only)
+docker run -p 50051:50051 -e DISABLE_REFLECTION_V1=true ghcr.io/jsr-probitas/echo-grpc:latest
 ```
 
 ## API

--- a/echo-grpc/config.go
+++ b/echo-grpc/config.go
@@ -7,9 +7,11 @@ import (
 )
 
 type Config struct {
-	Host                  string
-	Port                  string
-	ReflectionIncludeDeps bool
+	Host                     string
+	Port                     string
+	ReflectionIncludeDeps    bool
+	DisableReflectionV1      bool
+	DisableReflectionV1Alpha bool
 }
 
 func LoadConfig() *Config {
@@ -17,9 +19,11 @@ func LoadConfig() *Config {
 	_ = godotenv.Load()
 
 	return &Config{
-		Host:                  getEnv("HOST", "0.0.0.0"),
-		Port:                  getEnv("PORT", "50051"),
-		ReflectionIncludeDeps: getEnvBool("REFLECTION_INCLUDE_DEPENDENCIES", false),
+		Host:                     getEnv("HOST", "0.0.0.0"),
+		Port:                     getEnv("PORT", "50051"),
+		ReflectionIncludeDeps:    getEnvBool("REFLECTION_INCLUDE_DEPENDENCIES", false),
+		DisableReflectionV1:      getEnvBool("DISABLE_REFLECTION_V1", false),
+		DisableReflectionV1Alpha: getEnvBool("DISABLE_REFLECTION_V1ALPHA", false),
 	}
 }
 

--- a/echo-grpc/docs/api.md
+++ b/echo-grpc/docs/api.md
@@ -605,7 +605,7 @@ grpcurl -plaintext -d '{"service": ""}' \
 
 ## Server Reflection
 
-The server supports gRPC server reflection for service discovery.
+The server supports gRPC server reflection for service discovery (both v1 and v1alpha versions).
 
 ```bash
 # List all services
@@ -617,6 +617,14 @@ grpcurl -plaintext localhost:50051 describe echo.v1.Echo
 # Describe message
 grpcurl -plaintext localhost:50051 describe echo.v1.EchoRequest
 ```
+
+### Environment Variables
+
+- `REFLECTION_INCLUDE_DEPENDENCIES` (default: `false`) - Include transitive dependencies in reflection responses
+- `DISABLE_REFLECTION_V1` (default: `false`) - Disable gRPC reflection v1 API
+- `DISABLE_REFLECTION_V1ALPHA` (default: `false`) - Disable gRPC reflection v1alpha API
+
+These flags allow testing client compatibility with different reflection API versions.
 
 ## Metadata
 

--- a/echo-grpc/main.go
+++ b/echo-grpc/main.go
@@ -30,7 +30,7 @@ func main() {
 	healthpb.RegisterHealthServer(s, healthServer)
 
 	// Enable server reflection (v1 and v1alpha)
-	server.RegisterReflection(s, cfg.ReflectionIncludeDeps)
+	server.RegisterReflection(s, cfg.ReflectionIncludeDeps, cfg.DisableReflectionV1, cfg.DisableReflectionV1Alpha)
 
 	log.Printf("Starting server on %s", cfg.Addr())
 	if err := s.Serve(lis); err != nil {


### PR DESCRIPTION
## Summary
- Add `DISABLE_REFLECTION_V1` and `DISABLE_REFLECTION_V1ALPHA` environment variables
- Enable selective disabling of gRPC reflection API versions
- Support testing client compatibility with different reflection protocol versions

## Changes
- Add `DisableReflectionV1` and `DisableReflectionV1Alpha` config fields
- Update `RegisterReflection()` to support version-specific registration control
- Skip reflection registration entirely when both versions are disabled
- Document new environment variables in API reference

## Testing
- All existing tests pass
- Lint and build successful
- No breaking changes to default behavior (both versions enabled by default)

## Usage Examples
```bash
# Disable v1alpha only (v1 only)
DISABLE_REFLECTION_V1ALPHA=true ./echo-grpc

# Disable v1 only (v1alpha only)
DISABLE_REFLECTION_V1=true ./echo-grpc

# Disable both
DISABLE_REFLECTION_V1=true DISABLE_REFLECTION_V1ALPHA=true ./echo-grpc
```