### PR TITLE
Rename repository to echo-servers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Probitas Test Servers
+# Echo Servers
 
-Docker images for testing HTTP, gRPC, and GraphQL clients.
+Echo servers for testing HTTP, gRPC, and GraphQL clients.
 
 ## Project Overview
 
@@ -12,7 +12,7 @@ Docker images for testing HTTP, gRPC, and GraphQL clients.
 ## Project Structure
 
 ```
-dockerfiles/
+echo-servers/
 ├── flake.nix                 # Nix development environment
 ├── justfile                  # Root justfile (imports submodules)
 ├── compose.yaml              # Local orchestration
@@ -156,7 +156,7 @@ RUN go generate ./...  # If needed
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o app .
 
 FROM scratch
-LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/dockerfiles"
+LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/echo-servers"
 LABEL org.opencontainers.image.description="Description of the server"
 LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /app/app /app

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# Probitas Test Servers
+# Echo Servers
 
-[![Build echo-http](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-http.yml)
-[![Build echo-grpc](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-grpc.yml)
-[![Build echo-graphql](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-graphql.yml)
+[![Build echo-http](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-http.yml)
+[![Build echo-grpc](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-grpc.yml)
+[![Build echo-graphql](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-graphql.yml)
 
-Docker images for testing [Probitas](https://github.com/jsr-probitas/probitas)
-clients.
+Echo servers for testing HTTP, gRPC, and GraphQL clients. Built for testing
+[Probitas](https://github.com/jsr-probitas/probitas) and other client
+implementations.
 
 ## Images
 
-| Image                               | Protocol | Default Port | Status                                                                                                                                                                                              |
-| ----------------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ghcr.io/jsr-probitas/echo-http`    | HTTP     | 80           | [![Docker](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-http.yml)       |
-| `ghcr.io/jsr-probitas/echo-grpc`    | gRPC     | 50051        | [![Docker](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-grpc.yml)       |
-| `ghcr.io/jsr-probitas/echo-graphql` | GraphQL  | 8080         | [![Docker](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-graphql.yml) |
+| Image                               | Protocol | Default Port | Status                                                                                                                                                                                                |
+| ----------------------------------- | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ghcr.io/jsr-probitas/echo-http`    | HTTP     | 80           | [![Docker](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-http.yml)       |
+| `ghcr.io/jsr-probitas/echo-grpc`    | gRPC     | 50051        | [![Docker](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-grpc.yml)       |
+| `ghcr.io/jsr-probitas/echo-graphql` | GraphQL  | 8080         | [![Docker](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-graphql.yml) |
 
 ## Quick Start
 

--- a/echo-graphql/Dockerfile
+++ b/echo-graphql/Dockerfile
@@ -22,7 +22,7 @@ RUN go run github.com/99designs/gqlgen generate
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o echo-graphql .
 
 FROM scratch
-LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/dockerfiles"
+LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/echo-servers"
 LABEL org.opencontainers.image.description="GraphQL echo server for testing GraphQL clients"
 LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /app/echo-graphql /echo-graphql

--- a/echo-graphql/README.md
+++ b/echo-graphql/README.md
@@ -1,7 +1,7 @@
 # echo-graphql
 
-[![Build](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-graphql.yml)
-[![Docker](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-graphql.yml)
+[![Build](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-graphql.yml)
+[![Docker](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-graphql.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-graphql.yml)
 
 GraphQL echo server for testing GraphQL clients.
 

--- a/echo-graphql/go.mod
+++ b/echo-graphql/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsr-probitas/dockerfiles/echo-graphql
+module github.com/jsr-probitas/echo-servers/echo-graphql
 
 go 1.24.0
 

--- a/echo-graphql/gqlgen.yml
+++ b/echo-graphql/gqlgen.yml
@@ -20,7 +20,7 @@ resolver:
   omit_template_comment: true
 
 autobind:
-  - github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model
+  - github.com/jsr-probitas/echo-servers/echo-graphql/graph/model
 
 models:
   ID:
@@ -30,14 +30,14 @@ models:
     model:
       - github.com/99designs/gqlgen/graphql.Int
   Message:
-    model: github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model.Message
+    model: github.com/jsr-probitas/echo-servers/echo-graphql/graph/model.Message
   EchoResult:
-    model: github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model.EchoResult
+    model: github.com/jsr-probitas/echo-servers/echo-graphql/graph/model.EchoResult
   Headers:
-    model: github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model.Headers
+    model: github.com/jsr-probitas/echo-servers/echo-graphql/graph/model.Headers
   HeaderEntry:
-    model: github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model.HeaderEntry
+    model: github.com/jsr-probitas/echo-servers/echo-graphql/graph/model.HeaderEntry
   NestedEcho:
-    model: github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model.NestedEcho
+    model: github.com/jsr-probitas/echo-servers/echo-graphql/graph/model.NestedEcho
   EchoListItem:
-    model: github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model.EchoListItem
+    model: github.com/jsr-probitas/echo-servers/echo-graphql/graph/model.EchoListItem

--- a/echo-graphql/graph/generated.go
+++ b/echo-graphql/graph/generated.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
-	"github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model"
+	"github.com/jsr-probitas/echo-servers/echo-graphql/graph/model"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -1134,7 +1134,7 @@ func (ec *executionContext) _Headers_all(ctx context.Context, field graphql.Coll
 			return ec.resolvers.Headers().All(ctx, obj)
 		},
 		nil,
-		ec.marshalNHeaderEntry2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntryᚄ,
+		ec.marshalNHeaderEntry2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntryᚄ,
 		true,
 		true,
 	)
@@ -1257,7 +1257,7 @@ func (ec *executionContext) _Mutation_createMessage(ctx context.Context, field g
 			return ec.resolvers.Mutation().CreateMessage(ctx, fc.Args["text"].(string))
 		},
 		nil,
-		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
+		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
 		true,
 		true,
 	)
@@ -1306,7 +1306,7 @@ func (ec *executionContext) _Mutation_updateMessage(ctx context.Context, field g
 			return ec.resolvers.Mutation().UpdateMessage(ctx, fc.Args["id"].(string), fc.Args["text"].(string))
 		},
 		nil,
-		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
+		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
 		true,
 		true,
 	)
@@ -1396,7 +1396,7 @@ func (ec *executionContext) _Mutation_batchCreateMessages(ctx context.Context, f
 			return ec.resolvers.Mutation().BatchCreateMessages(ctx, fc.Args["texts"].([]string))
 		},
 		nil,
-		ec.marshalNMessage2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessageᚄ,
+		ec.marshalNMessage2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessageᚄ,
 		true,
 		true,
 	)
@@ -1473,7 +1473,7 @@ func (ec *executionContext) _NestedEcho_child(ctx context.Context, field graphql
 			return obj.Child, nil
 		},
 		nil,
-		ec.marshalONestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho,
+		ec.marshalONestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho,
 		true,
 		false,
 	)
@@ -1632,7 +1632,7 @@ func (ec *executionContext) _Query_echoPartialError(ctx context.Context, field g
 			return ec.resolvers.Query().EchoPartialError(ctx, fc.Args["messages"].([]string))
 		},
 		nil,
-		ec.marshalNEchoResult2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResultᚄ,
+		ec.marshalNEchoResult2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResultᚄ,
 		true,
 		true,
 	)
@@ -1719,7 +1719,7 @@ func (ec *executionContext) _Query_echoHeaders(ctx context.Context, field graphq
 			return ec.resolvers.Query().EchoHeaders(ctx)
 		},
 		nil,
-		ec.marshalNHeaders2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaders,
+		ec.marshalNHeaders2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaders,
 		true,
 		true,
 	)
@@ -1759,7 +1759,7 @@ func (ec *executionContext) _Query_echoNested(ctx context.Context, field graphql
 			return ec.resolvers.Query().EchoNested(ctx, fc.Args["message"].(string), fc.Args["depth"].(int))
 		},
 		nil,
-		ec.marshalNNestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho,
+		ec.marshalNNestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho,
 		true,
 		true,
 	)
@@ -1806,7 +1806,7 @@ func (ec *executionContext) _Query_echoList(ctx context.Context, field graphql.C
 			return ec.resolvers.Query().EchoList(ctx, fc.Args["message"].(string), fc.Args["count"].(int))
 		},
 		nil,
-		ec.marshalNEchoListItem2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItemᚄ,
+		ec.marshalNEchoListItem2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItemᚄ,
 		true,
 		true,
 	)
@@ -2030,7 +2030,7 @@ func (ec *executionContext) _Subscription_messageCreated(ctx context.Context, fi
 			return ec.resolvers.Subscription().MessageCreated(ctx)
 		},
 		nil,
-		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
+		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
 		true,
 		true,
 	)
@@ -2109,7 +2109,7 @@ func (ec *executionContext) _Subscription_messageCreatedFiltered(ctx context.Con
 			return ec.resolvers.Subscription().MessageCreatedFiltered(ctx, fc.Args["textContains"].(*string))
 		},
 		nil,
-		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
+		ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage,
 		true,
 		true,
 	)
@@ -4738,7 +4738,7 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) marshalNEchoListItem2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.EchoListItem) graphql.Marshaler {
+func (ec *executionContext) marshalNEchoListItem2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.EchoListItem) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4762,7 +4762,7 @@ func (ec *executionContext) marshalNEchoListItem2ᚕᚖgithubᚗcomᚋjsrᚑprob
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNEchoListItem2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItem(ctx, sel, v[i])
+			ret[i] = ec.marshalNEchoListItem2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItem(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -4782,7 +4782,7 @@ func (ec *executionContext) marshalNEchoListItem2ᚕᚖgithubᚗcomᚋjsrᚑprob
 	return ret
 }
 
-func (ec *executionContext) marshalNEchoListItem2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItem(ctx context.Context, sel ast.SelectionSet, v *model.EchoListItem) graphql.Marshaler {
+func (ec *executionContext) marshalNEchoListItem2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoListItem(ctx context.Context, sel ast.SelectionSet, v *model.EchoListItem) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4792,7 +4792,7 @@ func (ec *executionContext) marshalNEchoListItem2ᚖgithubᚗcomᚋjsrᚑprobita
 	return ec._EchoListItem(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNEchoResult2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResultᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.EchoResult) graphql.Marshaler {
+func (ec *executionContext) marshalNEchoResult2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResultᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.EchoResult) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4816,7 +4816,7 @@ func (ec *executionContext) marshalNEchoResult2ᚕᚖgithubᚗcomᚋjsrᚑprobit
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNEchoResult2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResult(ctx, sel, v[i])
+			ret[i] = ec.marshalNEchoResult2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResult(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -4836,7 +4836,7 @@ func (ec *executionContext) marshalNEchoResult2ᚕᚖgithubᚗcomᚋjsrᚑprobit
 	return ret
 }
 
-func (ec *executionContext) marshalNEchoResult2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResult(ctx context.Context, sel ast.SelectionSet, v *model.EchoResult) graphql.Marshaler {
+func (ec *executionContext) marshalNEchoResult2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐEchoResult(ctx context.Context, sel ast.SelectionSet, v *model.EchoResult) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4846,7 +4846,7 @@ func (ec *executionContext) marshalNEchoResult2ᚖgithubᚗcomᚋjsrᚑprobitas�
 	return ec._EchoResult(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNHeaderEntry2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HeaderEntry) graphql.Marshaler {
+func (ec *executionContext) marshalNHeaderEntry2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntryᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.HeaderEntry) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4870,7 +4870,7 @@ func (ec *executionContext) marshalNHeaderEntry2ᚕᚖgithubᚗcomᚋjsrᚑprobi
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNHeaderEntry2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntry(ctx, sel, v[i])
+			ret[i] = ec.marshalNHeaderEntry2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntry(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -4890,7 +4890,7 @@ func (ec *executionContext) marshalNHeaderEntry2ᚕᚖgithubᚗcomᚋjsrᚑprobi
 	return ret
 }
 
-func (ec *executionContext) marshalNHeaderEntry2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntry(ctx context.Context, sel ast.SelectionSet, v *model.HeaderEntry) graphql.Marshaler {
+func (ec *executionContext) marshalNHeaderEntry2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaderEntry(ctx context.Context, sel ast.SelectionSet, v *model.HeaderEntry) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4900,11 +4900,11 @@ func (ec *executionContext) marshalNHeaderEntry2ᚖgithubᚗcomᚋjsrᚑprobitas
 	return ec._HeaderEntry(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNHeaders2githubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaders(ctx context.Context, sel ast.SelectionSet, v model.Headers) graphql.Marshaler {
+func (ec *executionContext) marshalNHeaders2githubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaders(ctx context.Context, sel ast.SelectionSet, v model.Headers) graphql.Marshaler {
 	return ec._Headers(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNHeaders2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaders(ctx context.Context, sel ast.SelectionSet, v *model.Headers) graphql.Marshaler {
+func (ec *executionContext) marshalNHeaders2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐHeaders(ctx context.Context, sel ast.SelectionSet, v *model.Headers) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4946,11 +4946,11 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
-func (ec *executionContext) marshalNMessage2githubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage(ctx context.Context, sel ast.SelectionSet, v model.Message) graphql.Marshaler {
+func (ec *executionContext) marshalNMessage2githubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage(ctx context.Context, sel ast.SelectionSet, v model.Message) graphql.Marshaler {
 	return ec._Message(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNMessage2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessageᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Message) graphql.Marshaler {
+func (ec *executionContext) marshalNMessage2ᚕᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessageᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Message) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -4974,7 +4974,7 @@ func (ec *executionContext) marshalNMessage2ᚕᚖgithubᚗcomᚋjsrᚑprobitas�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage(ctx, sel, v[i])
+			ret[i] = ec.marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -4994,7 +4994,7 @@ func (ec *executionContext) marshalNMessage2ᚕᚖgithubᚗcomᚋjsrᚑprobitas�
 	return ret
 }
 
-func (ec *executionContext) marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage(ctx context.Context, sel ast.SelectionSet, v *model.Message) graphql.Marshaler {
+func (ec *executionContext) marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐMessage(ctx context.Context, sel ast.SelectionSet, v *model.Message) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -5004,11 +5004,11 @@ func (ec *executionContext) marshalNMessage2ᚖgithubᚗcomᚋjsrᚑprobitasᚋd
 	return ec._Message(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNNestedEcho2githubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho(ctx context.Context, sel ast.SelectionSet, v model.NestedEcho) graphql.Marshaler {
+func (ec *executionContext) marshalNNestedEcho2githubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho(ctx context.Context, sel ast.SelectionSet, v model.NestedEcho) graphql.Marshaler {
 	return ec._NestedEcho(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNNestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho(ctx context.Context, sel ast.SelectionSet, v *model.NestedEcho) graphql.Marshaler {
+func (ec *executionContext) marshalNNestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho(ctx context.Context, sel ast.SelectionSet, v *model.NestedEcho) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -5347,7 +5347,7 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return res
 }
 
-func (ec *executionContext) marshalONestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋdockerfilesᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho(ctx context.Context, sel ast.SelectionSet, v *model.NestedEcho) graphql.Marshaler {
+func (ec *executionContext) marshalONestedEcho2ᚖgithubᚗcomᚋjsrᚑprobitasᚋechoᚑserversᚋechoᚑgraphqlᚋgraphᚋmodelᚐNestedEcho(ctx context.Context, sel ast.SelectionSet, v *model.NestedEcho) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/echo-graphql/graph/resolver.go
+++ b/echo-graphql/graph/resolver.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model"
+	"github.com/jsr-probitas/echo-servers/echo-graphql/graph/model"
 )
 
 // filteredSubscriber represents a subscriber with optional text filter

--- a/echo-graphql/graph/resolver_test.go
+++ b/echo-graphql/graph/resolver_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 
-	"github.com/jsr-probitas/dockerfiles/echo-graphql/graph"
+	"github.com/jsr-probitas/echo-servers/echo-graphql/graph"
 )
 
 func setupTestClient(t *testing.T) *client.Client {

--- a/echo-graphql/graph/schema.resolvers.go
+++ b/echo-graphql/graph/schema.resolvers.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model"
+	"github.com/jsr-probitas/echo-servers/echo-graphql/graph/model"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 

--- a/echo-graphql/main.go
+++ b/echo-graphql/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/gorilla/websocket"
 
-	"github.com/jsr-probitas/dockerfiles/echo-graphql/graph"
-	"github.com/jsr-probitas/dockerfiles/echo-graphql/graph/model"
+	"github.com/jsr-probitas/echo-servers/echo-graphql/graph"
+	"github.com/jsr-probitas/echo-servers/echo-graphql/graph/model"
 )
 
 // requestContextMiddleware injects the http.Request into context for header access

--- a/echo-grpc/Dockerfile
+++ b/echo-grpc/Dockerfile
@@ -19,7 +19,7 @@ RUN protoc -I proto --go_out=proto --go_opt=paths=source_relative \
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o echo-grpc .
 
 FROM scratch
-LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/dockerfiles"
+LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/echo-servers"
 LABEL org.opencontainers.image.description="gRPC echo server for testing gRPC clients"
 LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /app/echo-grpc /echo-grpc

--- a/echo-grpc/README.md
+++ b/echo-grpc/README.md
@@ -1,7 +1,7 @@
 # echo-grpc
 
-[![Build](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-grpc.yml)
-[![Docker](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-grpc.yml)
+[![Build](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-grpc.yml)
+[![Docker](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-grpc.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-grpc.yml)
 
 gRPC echo server for testing gRPC clients.
 

--- a/echo-grpc/go.mod
+++ b/echo-grpc/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsr-probitas/dockerfiles/echo-grpc
+module github.com/jsr-probitas/echo-servers/echo-grpc
 
 go 1.24.0
 

--- a/echo-grpc/main.go
+++ b/echo-grpc/main.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/grpc"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
-	pb "github.com/jsr-probitas/dockerfiles/echo-grpc/proto"
-	"github.com/jsr-probitas/dockerfiles/echo-grpc/server"
+	pb "github.com/jsr-probitas/echo-servers/echo-grpc/proto"
+	"github.com/jsr-probitas/echo-servers/echo-grpc/server"
 )
 
 func main() {

--- a/echo-grpc/proto/echo.pb.go
+++ b/echo-grpc/proto/echo.pb.go
@@ -38,7 +38,7 @@ const file_echo_proto_rawDesc = "" +
 	"\x14EchoErrorWithDetails\x12$.echo.v1.EchoErrorWithDetailsRequest\x1a\x15.echo.v1.EchoResponse\x12E\n" +
 	"\fServerStream\x12\x1c.echo.v1.ServerStreamRequest\x1a\x15.echo.v1.EchoResponse0\x01\x12=\n" +
 	"\fClientStream\x12\x14.echo.v1.EchoRequest\x1a\x15.echo.v1.EchoResponse(\x01\x12F\n" +
-	"\x13BidirectionalStream\x12\x14.echo.v1.EchoRequest\x1a\x15.echo.v1.EchoResponse(\x010\x01B5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"\x13BidirectionalStream\x12\x14.echo.v1.EchoRequest\x1a\x15.echo.v1.EchoResponse(\x010\x01B6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var file_echo_proto_goTypes = []any{
 	(*EchoRequest)(nil),                 // 0: echo.v1.EchoRequest

--- a/echo-grpc/proto/echo.proto
+++ b/echo-grpc/proto/echo.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 import "echo_deadline.proto";
 import "echo_metadata.proto";

--- a/echo-grpc/proto/echo_deadline.pb.go
+++ b/echo-grpc/proto/echo_deadline.pb.go
@@ -136,7 +136,7 @@ const file_echo_deadline_proto_rawDesc = "" +
 	"\x14EchoDeadlineResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x122\n" +
 	"\x15deadline_remaining_ms\x18\x02 \x01(\x03R\x13deadlineRemainingMs\x12!\n" +
-	"\fhas_deadline\x18\x03 \x01(\bR\vhasDeadlineB5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"\fhas_deadline\x18\x03 \x01(\bR\vhasDeadlineB6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_deadline_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_deadline.proto
+++ b/echo-grpc/proto/echo_deadline.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 message EchoDeadlineRequest {
   string message = 1;

--- a/echo-grpc/proto/echo_errors.pb.go
+++ b/echo-grpc/proto/echo_errors.pb.go
@@ -227,7 +227,7 @@ const file_echo_errors_proto_rawDesc = "" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\"L\n" +
 	"\x0eQuotaViolation\x12\x18\n" +
 	"\asubject\x18\x01 \x01(\tR\asubject\x12 \n" +
-	"\vdescription\x18\x02 \x01(\tR\vdescriptionB5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"\vdescription\x18\x02 \x01(\tR\vdescriptionB6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_errors_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_errors.proto
+++ b/echo-grpc/proto/echo_errors.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 message ErrorDetail {
   string type = 1;

--- a/echo-grpc/proto/echo_metadata.pb.go
+++ b/echo-grpc/proto/echo_metadata.pb.go
@@ -228,7 +228,7 @@ const file_echo_metadata_proto_rawDesc = "" +
 	"\btrailers\x18\x02 \x03(\v2..echo.v1.EchoWithTrailersRequest.TrailersEntryR\btrailers\x1a;\n" +
 	"\rTrailersEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_metadata_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_metadata.proto
+++ b/echo-grpc/proto/echo_metadata.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 message MetadataValues {
   repeated string values = 1;

--- a/echo-grpc/proto/echo_payload.pb.go
+++ b/echo-grpc/proto/echo_payload.pb.go
@@ -138,7 +138,7 @@ const file_echo_payload_proto_rawDesc = "" +
 	"\x18EchoLargePayloadResponse\x12\x18\n" +
 	"\apayload\x18\x01 \x01(\fR\apayload\x12\x1f\n" +
 	"\vactual_size\x18\x02 \x01(\x05R\n" +
-	"actualSizeB5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"actualSizeB6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_payload_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_payload.proto
+++ b/echo-grpc/proto/echo_payload.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 message EchoLargePayloadRequest {
   int32 size_bytes = 1;  // Size of payload to return (max 10MB)

--- a/echo-grpc/proto/echo_response.pb.go
+++ b/echo-grpc/proto/echo_response.pb.go
@@ -84,7 +84,7 @@ const file_echo_response_proto_rawDesc = "" +
 	"\bmetadata\x18\x02 \x03(\v2#.echo.v1.EchoResponse.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_response_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_response.proto
+++ b/echo-grpc/proto/echo_response.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 message EchoResponse {
   string message = 1;

--- a/echo-grpc/proto/echo_stream.pb.go
+++ b/echo-grpc/proto/echo_stream.pb.go
@@ -91,7 +91,7 @@ const file_echo_stream_proto_rawDesc = "" +
 	"\amessage\x18\x01 \x01(\tR\amessage\x12\x14\n" +
 	"\x05count\x18\x02 \x01(\x05R\x05count\x12\x1f\n" +
 	"\vinterval_ms\x18\x03 \x01(\x05R\n" +
-	"intervalMsB5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"intervalMsB6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_stream_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_stream.proto
+++ b/echo-grpc/proto/echo_stream.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 message ServerStreamRequest {
   string message = 1;

--- a/echo-grpc/proto/echo_unary.pb.go
+++ b/echo-grpc/proto/echo_unary.pb.go
@@ -256,7 +256,7 @@ const file_echo_unary_proto_rawDesc = "" +
 	"\x1bEchoErrorWithDetailsRequest\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\x05R\x04code\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12.\n" +
-	"\adetails\x18\x03 \x03(\v2\x14.echo.v1.ErrorDetailR\adetailsB5Z3github.com/jsr-probitas/dockerfiles/echo-grpc/protob\x06proto3"
+	"\adetails\x18\x03 \x03(\v2\x14.echo.v1.ErrorDetailR\adetailsB6Z4github.com/jsr-probitas/echo-servers/echo-grpc/protob\x06proto3"
 
 var (
 	file_echo_unary_proto_rawDescOnce sync.Once

--- a/echo-grpc/proto/echo_unary.proto
+++ b/echo-grpc/proto/echo_unary.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package echo.v1;
 
-option go_package = "github.com/jsr-probitas/dockerfiles/echo-grpc/proto";
+option go_package = "github.com/jsr-probitas/echo-servers/echo-grpc/proto";
 
 import "echo_errors.proto";
 

--- a/echo-grpc/server/echo.go
+++ b/echo-grpc/server/echo.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	pb "github.com/jsr-probitas/dockerfiles/echo-grpc/proto"
+	pb "github.com/jsr-probitas/echo-servers/echo-grpc/proto"
 )
 
 const (

--- a/echo-grpc/server/echo_test.go
+++ b/echo-grpc/server/echo_test.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
-	pb "github.com/jsr-probitas/dockerfiles/echo-grpc/proto"
+	pb "github.com/jsr-probitas/echo-servers/echo-grpc/proto"
 )
 
 func setupTestServer(t *testing.T) (pb.EchoClient, func()) {

--- a/echo-http/Dockerfile
+++ b/echo-http/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o echo-http .
 
 FROM scratch
-LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/dockerfiles"
+LABEL org.opencontainers.image.source="https://github.com/jsr-probitas/echo-servers"
 LABEL org.opencontainers.image.description="HTTP echo server for testing HTTP clients"
 LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /app/echo-http /echo-http

--- a/echo-http/README.md
+++ b/echo-http/README.md
@@ -1,7 +1,7 @@
 # echo-http
 
-[![Build](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/build.echo-http.yml)
-[![Docker](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/dockerfiles/actions/workflows/docker.echo-http.yml)
+[![Build](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/build.echo-http.yml)
+[![Docker](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-http.yml/badge.svg)](https://github.com/jsr-probitas/echo-servers/actions/workflows/docker.echo-http.yml)
 
 HTTP echo server for testing HTTP clients.
 

--- a/echo-http/go.mod
+++ b/echo-http/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsr-probitas/dockerfiles/echo-http
+module github.com/jsr-probitas/echo-servers/echo-http
 
 go 1.23
 

--- a/echo-http/main.go
+++ b/echo-http/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
-	"github.com/jsr-probitas/dockerfiles/echo-http/handlers"
+	"github.com/jsr-probitas/echo-servers/echo-http/handlers"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

Update all references from `jsr-probitas/dockerfiles` to `jsr-probitas/echo-servers` to better reflect the repository's purpose as a collection of echo servers for testing HTTP, gRPC, and GraphQL clients.

## Changes

### Go Module Paths
- ✅ Updated all `go.mod` files with new module paths
- ✅ Updated import statements in all Go source files
- ✅ Updated Protocol Buffer `go_package` options

### Documentation
- ✅ Updated project title: "Probitas Test Servers" → "Echo Servers"
- ✅ Updated repository descriptions in README.md and CLAUDE.md
- ✅ Updated directory structure references: `dockerfiles/` → `echo-servers/`
- ✅ Updated GitHub Actions badge URLs

### Configuration
- ✅ Updated Docker OCI image source labels
- ✅ Updated gqlgen.yml model paths

## Breaking Changes

⚠️ **Go import paths have changed:**

```diff
- github.com/jsr-probitas/dockerfiles/echo-http
+ github.com/jsr-probitas/echo-servers/echo-http

- github.com/jsr-probitas/dockerfiles/echo-grpc
+ github.com/jsr-probitas/echo-servers/echo-grpc

- github.com/jsr-probitas/dockerfiles/echo-graphql
+ github.com/jsr-probitas/echo-servers/echo-graphql
```

## Verification

All checks pass:

```bash
✓ just lint   # 0 issues
✓ just test   # all tests pass
✓ just build  # builds successfully
```

## Files Changed

37 files updated (91 insertions, 90 deletions)

- Documentation: README.md, CLAUDE.md, service READMEs
- Go modules: 3 go.mod files
- Go source: 10 files (main.go, server/, graph/)
- Proto files: 16 files (.proto and generated .pb.go)
- Configuration: 4 files (Dockerfiles, gqlgen.yml)