### PR TITLE
Add /response-header endpoint for testing HTTP client header handling

### DIFF
--- a/echo-http/docs/api.md
+++ b/echo-http/docs/api.md
@@ -148,6 +148,46 @@ curl http://localhost:80/headers \
 }
 ```
 
+### GET /response-header
+
+Set response headers based on query parameters. Each query parameter key-value
+pair is set as a response header. Useful for testing HTTP client header processing.
+
+**Request:**
+
+```bash
+curl -i "http://localhost:80/response-header?X-Custom-Header=custom-value&Cache-Control=no-cache"
+```
+
+**Response:**
+
+```
+HTTP/1.1 200 OK
+Cache-Control: no-cache
+Content-Type: application/json
+X-Custom-Header: custom-value
+
+{
+  "headers": {
+    "X-Custom-Header": "custom-value",
+    "Cache-Control": "no-cache"
+  }
+}
+```
+
+**Examples:**
+
+```bash
+# Set custom response headers
+curl -i "http://localhost:80/response-header?X-Request-Id=12345&X-Correlation-Id=abc-xyz"
+
+# Test cache control headers
+curl -i "http://localhost:80/response-header?Cache-Control=max-age=3600&Expires=Wed,%2021%20Oct%202025%2007:28:00%20GMT"
+
+# Set content language
+curl -i "http://localhost:80/response-header?Content-Language=en-US"
+```
+
 ### GET /status/{code}
 
 Return the specified HTTP status code.

--- a/echo-http/handlers/response_header.go
+++ b/echo-http/handlers/response_header.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type ResponseHeaderResponse struct {
+	Headers map[string]string `json:"headers"`
+}
+
+// ResponseHeaderHandler sets response headers based on query parameters.
+// Each query parameter key-value pair is set as a response header.
+// Example: GET /response-header?X-Custom-Header=value&Content-Language=en
+func ResponseHeaderHandler(w http.ResponseWriter, r *http.Request) {
+	response := ResponseHeaderResponse{
+		Headers: make(map[string]string),
+	}
+
+	// Set each query parameter as a response header
+	for key, values := range r.URL.Query() {
+		if len(values) > 0 {
+			w.Header().Set(key, values[0])
+			response.Headers[key] = values[0]
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}

--- a/echo-http/handlers/response_header_test.go
+++ b/echo-http/handlers/response_header_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResponseHeaderHandler(t *testing.T) {
+	t.Run("sets response headers from query parameters", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/response-header?X-Custom-Header=custom-value&X-Request-Id=12345", nil)
+		rec := httptest.NewRecorder()
+
+		ResponseHeaderHandler(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		contentType := rec.Header().Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", contentType)
+		}
+
+		// Check response headers
+		if rec.Header().Get("X-Custom-Header") != "custom-value" {
+			t.Errorf("expected X-Custom-Header=custom-value, got %s", rec.Header().Get("X-Custom-Header"))
+		}
+
+		if rec.Header().Get("X-Request-Id") != "12345" {
+			t.Errorf("expected X-Request-Id=12345, got %s", rec.Header().Get("X-Request-Id"))
+		}
+
+		// Check response body
+		var resp ResponseHeaderResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if resp.Headers["X-Custom-Header"] != "custom-value" {
+			t.Errorf("expected body X-Custom-Header=custom-value, got %s", resp.Headers["X-Custom-Header"])
+		}
+
+		if resp.Headers["X-Request-Id"] != "12345" {
+			t.Errorf("expected body X-Request-Id=12345, got %s", resp.Headers["X-Request-Id"])
+		}
+	})
+
+	t.Run("handles standard HTTP headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/response-header?Cache-Control=no-cache&Content-Language=en-US", nil)
+		rec := httptest.NewRecorder()
+
+		ResponseHeaderHandler(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		if rec.Header().Get("Cache-Control") != "no-cache" {
+			t.Errorf("expected Cache-Control=no-cache, got %s", rec.Header().Get("Cache-Control"))
+		}
+
+		if rec.Header().Get("Content-Language") != "en-US" {
+			t.Errorf("expected Content-Language=en-US, got %s", rec.Header().Get("Content-Language"))
+		}
+	})
+
+	t.Run("handles empty query parameters", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/response-header", nil)
+		rec := httptest.NewRecorder()
+
+		ResponseHeaderHandler(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		var resp ResponseHeaderResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+
+		if len(resp.Headers) != 0 {
+			t.Errorf("expected empty headers map, got %d headers", len(resp.Headers))
+		}
+	})
+
+	t.Run("uses first value when multiple values exist", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/response-header?X-Multi=first&X-Multi=second", nil)
+		rec := httptest.NewRecorder()
+
+		ResponseHeaderHandler(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200, got %d", rec.Code)
+		}
+
+		headerValue := rec.Header().Get("X-Multi")
+		if headerValue != "first" {
+			t.Errorf("expected X-Multi=first, got %s", headerValue)
+		}
+	})
+}

--- a/echo-http/main.go
+++ b/echo-http/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	// Utility endpoints
 	r.Get("/headers", handlers.HeadersHandler)
+	r.Get("/response-header", handlers.ResponseHeaderHandler)
 	r.Get("/ip", handlers.IPHandler)
 	r.Get("/user-agent", handlers.UserAgentHandler)
 


### PR DESCRIPTION
## Summary
- Add new GET `/response-header` endpoint to echo-http server
- Query parameters are reflected as HTTP response headers
- Includes comprehensive test suite with 4 test cases
- Documentation added to API reference with usage examples

## Why
HTTP client developers need a reliable way to test how their clients handle various response headers (Cache-Control, Content-Language, custom headers, etc.) without deploying custom server code. This endpoint enables testing by accepting query parameters and reflecting them as response headers, making it easy to verify client-side header processing logic.

This complements the existing `/headers` endpoint (which echoes request headers) by providing control over the response side, completing the request/response testing toolkit.

## Test Plan
- [x] All tests pass (`just echo-http::test` - 4 new test cases added)
- [x] Linting passes (`just echo-http::lint` - 0 issues)
- [x] Build succeeds (`just echo-http::build`)
- [ ] Manual test: `curl -i "http://localhost:18080/response-header?X-Custom=value"`
- [ ] Verify response headers include `X-Custom: value`
- [ ] Test with standard headers like `Cache-Control` and `Content-Language`