### PR TITLE
Complete echo-http environment variable documentation

### DIFF
--- a/echo-http/config.go
+++ b/echo-http/config.go
@@ -28,9 +28,6 @@ type Config struct {
 	AuthCodeSessionTTL          int
 	AuthCodeValidateRedirectURI bool
 	AuthCodeAllowedRedirectURIs string
-
-	// OIDC Configuration (id_token specific)
-	OIDCEnableJWTSigning bool
 }
 
 func LoadConfig() *Config {
@@ -46,7 +43,7 @@ func LoadConfig() *Config {
 		AuthAllowedClientSecret: getEnv("AUTH_ALLOWED_CLIENT_SECRET", ""),
 		AuthSupportedScopes:     parseScopes(getEnv("AUTH_SUPPORTED_SCOPES", "openid,profile,email")),
 		AuthTokenExpiry:         getIntEnv("AUTH_TOKEN_EXPIRY", 3600),
-		AuthAllowedGrantTypes:   parseGrantTypes(getEnv("AUTH_ALLOWED_GRANT_TYPES", "authorization_code,client_credentials")),
+		AuthAllowedGrantTypes:   parseGrantTypes(getEnv("AUTH_ALLOWED_GRANT_TYPES", "authorization_code,client_credentials,password,refresh_token")),
 
 		// Resource Owner Password Credentials / Basic Auth settings
 		AuthAllowedUsername: getEnv("AUTH_ALLOWED_USERNAME", "testuser"),
@@ -57,9 +54,6 @@ func LoadConfig() *Config {
 		AuthCodeSessionTTL:          getIntEnv("AUTH_CODE_SESSION_TTL", 300),
 		AuthCodeValidateRedirectURI: getBoolEnv("AUTH_CODE_VALIDATE_REDIRECT_URI", false),
 		AuthCodeAllowedRedirectURIs: getEnv("AUTH_CODE_ALLOWED_REDIRECT_URIS", ""),
-
-		// OIDC settings (id_token specific)
-		OIDCEnableJWTSigning: getBoolEnv("OIDC_ENABLE_JWT_SIGNING", false),
 	}
 }
 

--- a/echo-http/docs/api.md
+++ b/echo-http/docs/api.md
@@ -19,18 +19,28 @@
 | `HOST`   | `0.0.0.0` | Bind address |
 | `PORT`   | `80`      | Listen port  |
 
+### Authentication Configuration
+
+Shared credentials used across all authentication methods.
+
+| Variable                 | Default    | Description                                                    |
+| ------------------------ | ---------- | -------------------------------------------------------------- |
+| `AUTH_ALLOWED_USERNAME`  | `testuser` | Username for Basic Auth, Bearer Token, and OAuth2/OIDC flows   |
+| `AUTH_ALLOWED_PASSWORD`  | `testpass` | Password for Basic Auth, Bearer Token, and OAuth2/OIDC flows   |
+
 ### OAuth2/OIDC Configuration
 
 Configure OAuth2/OIDC server behavior with these environment variables:
 
 **OAuth2 Configuration (shared across all flows):**
 
-| Variable                     | Default                 | Description                                    |
-| ---------------------------- | ----------------------- | ---------------------------------------------- |
-| `AUTH_ALLOWED_CLIENT_ID`     | (empty - accept any)    | Allowed client_id for validation (empty = any) |
-| `AUTH_ALLOWED_CLIENT_SECRET` | (empty - public client) | Required client_secret (empty = not required)  |
-| `AUTH_SUPPORTED_SCOPES`      | `openid,profile,email`  | Comma-separated list of supported scopes       |
-| `AUTH_TOKEN_EXPIRY`          | `3600`                  | Access token expiry in seconds                 |
+| Variable                     | Default                                                           | Description                                    |
+| ---------------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
+| `AUTH_ALLOWED_CLIENT_ID`     | (empty - accept any)                                              | Allowed client_id for validation (empty = any) |
+| `AUTH_ALLOWED_CLIENT_SECRET` | (empty - public client)                                           | Required client_secret (empty = not required)  |
+| `AUTH_SUPPORTED_SCOPES`      | `openid,profile,email`                                            | Comma-separated list of supported scopes       |
+| `AUTH_TOKEN_EXPIRY`          | `3600`                                                            | Access token expiry in seconds                 |
+| `AUTH_ALLOWED_GRANT_TYPES`   | `authorization_code,client_credentials,password,refresh_token`    | Comma-separated list of allowed grant types    |
 
 **Authorization Code Flow Configuration:**
 
@@ -41,12 +51,6 @@ Configure OAuth2/OIDC server behavior with these environment variables:
 | `AUTH_CODE_VALIDATE_REDIRECT_URI` | `false`             | Enable redirect_uri validation          |
 | `AUTH_CODE_ALLOWED_REDIRECT_URIS` | (empty - allow all) | Comma-separated redirect URI patterns   |
 
-**OIDC Configuration (id_token specific):**
-
-| Variable                  | Default | Description                                    |
-| ------------------------- | ------- | ---------------------------------------------- |
-| `OIDC_ENABLE_JWT_SIGNING` | `false` | Enable JWT signing (currently not implemented) |
-
 **Example Configuration:**
 
 ```bash
@@ -55,6 +59,7 @@ export AUTH_ALLOWED_CLIENT_ID=my-app-client-id
 export AUTH_ALLOWED_CLIENT_SECRET=my-app-secret
 export AUTH_SUPPORTED_SCOPES=openid,profile,email,custom_scope
 export AUTH_TOKEN_EXPIRY=3600
+export AUTH_ALLOWED_GRANT_TYPES=authorization_code,client_credentials,password,refresh_token
 export AUTH_CODE_REQUIRE_PKCE=true
 export AUTH_CODE_VALIDATE_REDIRECT_URI=true
 export AUTH_CODE_ALLOWED_REDIRECT_URIS=http://localhost:*,https://myapp.com/callback
@@ -489,8 +494,8 @@ Validate Basic Authentication credentials.
 
 Configure credentials via environment variables:
 
-- `AUTH_ALLOWED_USERNAME`: Expected username
-- `AUTH_ALLOWED_PASSWORD`: Expected password
+- `AUTH_ALLOWED_USERNAME`: Expected username (default: `testuser`)
+- `AUTH_ALLOWED_PASSWORD`: Expected password (default: `testpass`)
 
 **Request:**
 
@@ -515,8 +520,8 @@ Validate Bearer token authentication. The expected token is SHA1(username:passwo
 
 Configure credentials via environment variables:
 
-- `AUTH_ALLOWED_USERNAME`: Username
-- `AUTH_ALLOWED_PASSWORD`: Password
+- `AUTH_ALLOWED_USERNAME`: Username (default: `testuser`)
+- `AUTH_ALLOWED_PASSWORD`: Password (default: `testpass`)
 
 Generate the token:
 

--- a/echo-http/handlers/config.go
+++ b/echo-http/handlers/config.go
@@ -22,9 +22,6 @@ type Config struct {
 	AuthCodeSessionTTL          int
 	AuthCodeValidateRedirectURI bool
 	AuthCodeAllowedRedirectURIs string
-
-	// OIDC Configuration (id_token specific)
-	OIDCEnableJWTSigning bool
 }
 
 // SetConfig sets the global configuration for handlers.

--- a/echo-http/main.go
+++ b/echo-http/main.go
@@ -33,7 +33,6 @@ func main() {
 		AuthCodeSessionTTL:          cfg.AuthCodeSessionTTL,
 		AuthCodeValidateRedirectURI: cfg.AuthCodeValidateRedirectURI,
 		AuthCodeAllowedRedirectURIs: cfg.AuthCodeAllowedRedirectURIs,
-		OIDCEnableJWTSigning:        cfg.OIDCEnableJWTSigning,
 	})
 
 	r := chi.NewRouter()


### PR DESCRIPTION
## Summary
- Fix `AUTH_ALLOWED_GRANT_TYPES` default to include all 4 supported grant types (authorization_code, client_credentials, password, refresh_token)
- Add new "Authentication Configuration" section documenting shared credentials
- Document `AUTH_ALLOWED_USERNAME` and `AUTH_ALLOWED_PASSWORD` with their default values
- Remove unused `OIDC_ENABLE_JWT_SIGNING` configuration option

## Why

The API documentation was incomplete and misleading:

1. **Incomplete default values**: `AUTH_ALLOWED_GRANT_TYPES` default only listed 2 out of 4 implemented grant types, preventing users from discovering password and refresh_token flows without reading source code.

2. **Missing shared credentials**: `AUTH_ALLOWED_USERNAME` and `AUTH_ALLOWED_PASSWORD` were undocumented despite being used across Basic Auth, Bearer Token, and OAuth2/OIDC flows. Users had no way to know these variables existed or their default values.

3. **Dead code confusion**: `OIDC_ENABLE_JWT_SIGNING` was defined but never used—the implementation always generates JWT with `alg="none"`. This created false expectations about signing capabilities.

These gaps made it difficult for users to configure authentication correctly and understand which features were actually available.

## Test Plan
- [x] Run `just echo-http::lint` - passes
- [x] Run `just echo-http::test` - all tests pass
- [x] Run `just echo-http::build` - builds successfully
- [x] Verify all environment variables in docs match implementation